### PR TITLE
Mark the generated option lists as appendixes and link to them

### DIFF
--- a/books/assembly-configuring-kafka.adoc
+++ b/books/assembly-configuring-kafka.adoc
@@ -7,6 +7,8 @@ The configuration file has to be readable by the `kafka` user.
 AMQ Streams ships an example configuration file that highlights various basic and advanced features of the product.
 It can be found under `config/server.properties` in the AMQ Streams installation directory.
 
+For list of all supported Kafka broker configuration options, see xref:broker-configuration-parameters-{context}[].
+
 include::con-kafka-zookeeper-configuration.adoc[leveloffset=+1]
 include::con-kafka-listener-configuration.adoc[leveloffset=+1]
 include::con-kafka-commit-log-configuration.adoc[leveloffset=+1]

--- a/books/assembly-configuring-kafka.adoc
+++ b/books/assembly-configuring-kafka.adoc
@@ -7,6 +7,7 @@ The configuration file has to be readable by the `kafka` user.
 AMQ Streams ships an example configuration file that highlights various basic and advanced features of the product.
 It can be found under `config/server.properties` in the AMQ Streams installation directory.
 
+This chapter will explain the most important configuration options only.
 For list of all supported Kafka broker configuration options, see xref:broker-configuration-parameters-{context}[].
 
 include::con-kafka-zookeeper-configuration.adoc[leveloffset=+1]

--- a/books/assembly-configuring-kafka.adoc
+++ b/books/assembly-configuring-kafka.adoc
@@ -8,7 +8,7 @@ AMQ Streams ships an example configuration file that highlights various basic an
 It can be found under `config/server.properties` in the AMQ Streams installation directory.
 
 This chapter will explain the most important configuration options only.
-For list of all supported Kafka broker configuration options, see xref:broker-configuration-parameters-{context}[].
+For a list of all supported Kafka broker configuration options, see xref:broker-configuration-parameters-{context}[].
 
 include::con-kafka-zookeeper-configuration.adoc[leveloffset=+1]
 include::con-kafka-listener-configuration.adoc[leveloffset=+1]

--- a/books/assembly-configuring-kafka.adoc
+++ b/books/assembly-configuring-kafka.adoc
@@ -7,8 +7,8 @@ The configuration file has to be readable by the `kafka` user.
 AMQ Streams ships an example configuration file that highlights various basic and advanced features of the product.
 It can be found under `config/server.properties` in the AMQ Streams installation directory.
 
-This chapter will explain the most important configuration options only.
-For a list of all supported Kafka broker configuration options, see xref:broker-configuration-parameters-{context}[].
+This chapter explains the most important configuration options.
+For a complete list of supported Kafka broker configuration options, see xref:broker-configuration-parameters-{context}[].
 
 include::con-kafka-zookeeper-configuration.adoc[leveloffset=+1]
 include::con-kafka-listener-configuration.adoc[leveloffset=+1]

--- a/books/master.adoc
+++ b/books/master.adoc
@@ -20,12 +20,16 @@ include::ref-topic-config.adoc[leveloffset=+1]
 
 [appendix]
 include::ref-consumer-config.adoc[leveloffset=+1]
+
 [appendix]
 include::ref-producer-config.adoc[leveloffset=+1]
+
 [appendix]
 include::ref-admin-client-config.adoc[leveloffset=+1]
+
 [appendix]
 include::ref-connect-config.adoc[leveloffset=+1]
+
 [appendix]
 include::ref-streams-config.adoc[leveloffset=+1]
 

--- a/books/master.adoc
+++ b/books/master.adoc
@@ -12,18 +12,21 @@ include::assembly-configuring-zookeeper.adoc[leveloffset=+1]
 
 include::assembly-configuring-kafka.adoc[leveloffset=+1]
 
+[appendix]
 include::ref-broker-config.adoc[leveloffset=+1]
 
+[appendix]
 include::ref-topic-config.adoc[leveloffset=+1]
 
+[appendix]
 include::ref-consumer-config.adoc[leveloffset=+1]
-
+[appendix]
 include::ref-producer-config.adoc[leveloffset=+1]
-
+[appendix]
 include::ref-admin-client-config.adoc[leveloffset=+1]
-
+[appendix]
 include::ref-connect-config.adoc[leveloffset=+1]
-
+[appendix]
 include::ref-streams-config.adoc[leveloffset=+1]
 
 // non-modularized content

--- a/books/proc-running-multinode-kafka-cluster.adoc
+++ b/books/proc-running-multinode-kafka-cluster.adoc
@@ -84,3 +84,4 @@ Sessions with Ephemerals (3):
 * For more information about installing AMQ Streams, see xref:proc-installing-amq-streams-{context}[].
 * For more information about configuring AMQ Streams, see xref:proc-configuring-amq-streams-{context}[].
 * For more information about running a Zookeeper cluster, see xref:proc-running-multinode-zookeeper-cluster-{context}[].
+* For more Kafka broker configuration options, see xref:broker-configuration-parameters-{context}[].

--- a/books/proc-running-multinode-kafka-cluster.adoc
+++ b/books/proc-running-multinode-kafka-cluster.adoc
@@ -84,4 +84,4 @@ Sessions with Ephemerals (3):
 * For more information about installing AMQ Streams, see xref:proc-installing-amq-streams-{context}[].
 * For more information about configuring AMQ Streams, see xref:proc-configuring-amq-streams-{context}[].
 * For more information about running a Zookeeper cluster, see xref:proc-running-multinode-zookeeper-cluster-{context}[].
-* For more Kafka broker configuration options, see xref:broker-configuration-parameters-{context}[].
+* For a complete list of supported Kafka broker configuration options, see xref:broker-configuration-parameters-{context}[].


### PR DESCRIPTION
This PR marks the newly added reference modules with lists of configuration options as appendixes. It also links the Kafka configuration from few places.