### PR TITLE
Add information about Kafka clients and Streams API

### DIFF
--- a/books/assembly-kafka-clients.adoc
+++ b/books/assembly-kafka-clients.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// master.adoc
+
+[id='assembly-kafka-clients-{context}']
+
+= Kafka clients
+
+Kafka Producer and Consumer APIs are together with Kafka AdminClient API part of the `kafka-clients` JAR package.
+The Producer API allows applications to send data to a Kafka broker.
+The Consumer API allows applications to consume data from a Kafka broker.
+The AdminClient API allows management of Kafka clusters (topics, brokers and so on).
+
+include::proc-adding-clients-dependency-to-maven-project.adoc[leveloffset=+1]

--- a/books/assembly-kafka-streams.adoc
+++ b/books/assembly-kafka-streams.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// master.adoc
+
+[id='assembly-kafka-streams-{context}']
+
+= Kafka Streams API
+
+The Kafka Streams API allows applications to receive data from input streams and process them into output streams.
+It is part of the `kafka-streams` JAR package which is available in the Red Hat Maven repository.
+
+include::proc-adding-streams-dependency-to-maven-project.adoc[leveloffset=+1]

--- a/books/common/attributes.adoc
+++ b/books/common/attributes.adoc
@@ -21,6 +21,10 @@
 // Source and download links
 :ReleaseDownload: https://github.com/strimzi/strimzi-kafka-operator/releases[GitHub^]
 
+// Maven dependencies
+:MavenRepo: https://maven.repository.redhat.com/earlyaccess/all/
+:ArtifactVersion: 2.0.0.redhat-00003
+
 // File locations
 :UpstreamDir: upstream/documentation/book
 

--- a/books/master.adoc
+++ b/books/master.adoc
@@ -18,6 +18,10 @@ include::assembly-scaling-clusters.adoc[leveloffset=+1]
 
 include::assembly-kafka-connect.adoc[leveloffset=+1]
 
+include::assembly-kafka-clients.adoc[leveloffset=+1]
+
+include::assembly-kafka-streams.adoc[leveloffset=+1]
+
 [appendix]
 include::ref-broker-config.adoc[leveloffset=+1]
 

--- a/books/proc-adding-clients-dependency-to-maven-project.adoc
+++ b/books/proc-adding-clients-dependency-to-maven-project.adoc
@@ -1,0 +1,63 @@
+// Module included in the following assemblies:
+//
+// assembly-kafka-clients.adoc
+
+[id='proc-adding-clients-dependency-to-maven-project-{context}']
+
+= Adding Kafka clients as a dependency to your Maven project
+
+This procedure shows you how to add the {ProductName} Java clients as a dependency to your Maven project.
+
+.Prerequisites
+
+* Maven project with existing `pom.xml`.
+
+.Procedure
+
+. Add the Red Hat Maven repository to the `<repositories>` section in your `pom.xml` file.
++
+[source,subs=attributes+,xml]
+----
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    
+    <!-- ... -->
+
+    <repositories>
+        <repository>
+            <id>redhat-maven</id>
+            <url>{MavenRepo}</url>
+        </repository>
+    </repositories>
+
+    <!-- ... -->
+
+</project>
+----
+
+. Add the clients to the `<dependencies>` section in your `pom.xml` file.
++
+[source,subs=attributes+,xml]
+----
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    
+    <!-- ... -->
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>{ArtifactVersion}</version>
+        </dependency>
+    </dependencies>
+
+    <!-- ... -->
+</project>
+----
+
+. Build your Maven project.

--- a/books/proc-adding-streams-dependency-to-maven-project.adoc
+++ b/books/proc-adding-streams-dependency-to-maven-project.adoc
@@ -1,0 +1,63 @@
+// Module included in the following assemblies:
+//
+// assembly-kafka-clients.adoc
+
+[id='proc-adding-clients-dependency-{context}']
+
+= Adding Kafka Streams API as a dependency to your Maven project
+
+This procedure shows you how to add the {ProductName} Java clients as a dependency to your Maven project.
+
+.Prerequisites
+
+* Maven project with existing `pom.xml`.
+
+.Procedure
+
+. Add the Red Hat Maven repository to the `<repositories>` section in your `pom.xml` file.
++
+[source,subs=attributes+,xml]
+----
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    
+    <!-- ... -->
+
+    <repositories>
+        <repository>
+            <id>redhat-maven</id>
+            <url>{MavenRepo}</url>
+        </repository>
+    </repositories>
+
+    <!-- ... -->
+
+</project>
+----
+
+. Add `kafka-streams` to the `<dependencies>` section in your `pom.xml` file.
++
+[source,subs=attributes+,xml]
+----
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    
+    <!-- ... -->
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-streams</artifactId>
+            <version>{ArtifactVersion}</version>
+        </dependency>
+    </dependencies>
+
+    <!-- ... -->
+</project>
+----
+
+. Build your Maven project.


### PR DESCRIPTION
The documentation right now doesn't have any information about the clients and the Streams API. We have these as dependencies in the Red Hat Maven repos and users can use them from there. Tis PR adds two chaptes about the clients and about Streams API. It currently contains only the procedure how to add the dependencies.