### PR TITLE
Update the Maven repository URL for the GA release

### DIFF
--- a/books/common/attributes.adoc
+++ b/books/common/attributes.adoc
@@ -26,7 +26,7 @@
 :ReleaseDownload: https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=distributions&product=jboss.amq.streams&productChanged=yes[Customer Portal^]
 
 // Maven dependencies
-:MavenRepo: https://maven.repository.redhat.com/earlyaccess/all/
+:MavenRepo: https://maven.repository.redhat.com/ga/
 :ArtifactVersion: 2.0.0.redhat-00003
 
 // File locations


### PR DESCRIPTION
In the GA release, users should use different Maven repository than in the beta. The Maven URL is in the attributes, so all we need to change is the `attributes.adoc` file.