### PR TITLE
Something approximating a better use of make

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 generator/target
 generator/.idea
 generator/*.iml
+generator/*.adoc
 out
 books/master.html
+Makefile.publish
+html/
+

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-make build check
+make buildall check

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,18 +1,3 @@
 #!/bin/sh
 
-SOURCES=books
-RELEASE_VERSION=1.0
-
-./.travis/check_docs.sh "$SOURCES"
-CHECK=$?
-
-mkdir -p out/html
-cp -vrL "$SOURCES/images" out/html/images
-asciidoctor -v --failure-level WARN -t -dbook -a ProductVersion=${RELEASE_VERSION} "$SOURCES/master.adoc" -o out/html/index.html
-GEN=$?
-
-if [ "$CHECK" != "0" -o "$GEN" != "0" ]; then
-  echo "Documentation errors: check output above"
-  exit 1
-fi
-
+make build check

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 BUILD_DIR := build
-CONFIG_DOCS=ref-broker-config.adoc ref-consumer-config.adoc ref-producer-config.adoc ref-admin-client-config.adoc ref-connect-config.adoc ref-streams-config.adoc ref-topic-config.adoc
-METRICS_DOCS=ref-mbeans-producer-gen.adoc ref-mbeans-consumer-gen.adoc ref-mbeans-kafka-connect-gen.adoc ref-mbeans-kafka-streams-gen.adoc
 
 include ./Makefile.os
 -include ./Makefile.publish
+
+build: html/index.html
+
+buildall: generated build
 
 clean: 
 	rm -r html || true
@@ -12,15 +14,9 @@ clean:
 check:
 	./.travis/check_docs.sh books
 
-$(CONFIG_DOCS):
-	$(MAKE) -C generator $@
-	cp generator/$@ books/$@
-
-$(METRICS_DOCS):
-	$(MAKE) -C generator $@
-	cp generator/$@ books/$@
-
-generated: $(METRICS_DOCS) $(CONFIG_DOCS)
+generated: 
+	$(MAKE) -C generator docs
+	cp -p generator/*.adoc books/
 
 html/index.html: books/*.adoc
 # Convert the asciidoc to html
@@ -28,11 +24,9 @@ html/index.html: books/*.adoc
 	$(CP) -vrL books/images html/images
 	asciidoctor -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) -a GithubVersion=$(GITHUB_VERSION) books/master.adoc -o html/index.html
 
-build: html/index.html
 
-buildall: generated build
 
 publish: build
 	rsync -av html/ $(PUBLISH_DEST)
 
-.PHONY: clean check generated $(CONFIG_DOCS) $(METRICS_DOCS) build buildall publish
+.PHONY: clean check generated build buildall publish

--- a/Makefile
+++ b/Makefile
@@ -1,108 +1,34 @@
 BUILD_DIR := build
+CONFIG_DOCS=ref-broker-config.adoc ref-consumer-config.adoc ref-producer-config.adoc ref-admin-client-config.adoc ref-connect-config.adoc ref-streams-config.adoc ref-topic-config.adoc
+METRICS_DOCS=ref-mbeans-producer-gen.adoc ref-mbeans-consumer-gen.adoc ref-mbeans-kafka-connect-gen.adoc ref-mbeans-kafka-streams-gen.adoc
 
-CCUTIL_ENABLED := \
-	$(shell which ccutil 1> /dev/null 2>&1 && echo yes || echo no)
+include ./Makefile.os
+-include ./Makefile.publish
 
-BOOK_SOURCES := $(shell find . -maxdepth 2 -type f -name master.adoc)
-//BOOK_SOURCES := $(filter-out ./broker-ocp/master.adoc,${BOOK_SOURCES})
-BOOK_TARGETS := \
-	${BOOK_SOURCES:%/master.adoc=${BUILD_DIR}/%/index.html} \
-	${BOOK_SOURCES:%/master.adoc=${BUILD_DIR}/%/images}
+clean: 
+	rm -r html
 
-IMAGE_SOURCES := $(shell find images -type f)
-IMAGE_TARGETS := \
-	${IMAGE_SOURCES:images/%=${BUILD_DIR}/images/%}
+check:
+	./.travis/check_docs.sh books
 
-ifeq (${CCUTIL_ENABLED},yes)
-CCUTIL_TARGETS := \
-	${BOOK_SOURCES:%/master.adoc=${BUILD_DIR}/ccutil/%/index.html}
-else
-CCUTIL_TARGETS :=
-endif
+$(CONFIG_DOCS):
+	$(MAKE) -C generator $@
+	cp generator/$@ books/$@
 
-EXTRA_SOURCES := $(shell find internal -type f -name \*.adoc)
-EXTRA_TARGETS := \
-	${EXTRA_SOURCES:%.adoc=${BUILD_DIR}/%.html} \
-	${BUILD_DIR}/index.html
+$(METRICS_DOCS): 
+	$(MAKE) -C generator $@
+	cp generator/$@ books/$@
 
-PREVIEW_ATTRIBUTES := $(shell sed 's/^/-a /' .preview-attributes)
+books/master.html: $(CONFIG_DOCS) $(METRICS_DOCS)
+# Convert the asciidoc to html
+	mkdir -p html
+	$(CP) -vrL books/images html/images
+	asciidoctor -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) -a GithubVersion=$(GITHUB_VERSION) books/master.adoc -o html/index.html
 
-.PHONY: default
-default: preview
+build: books/master.html
 
-.PHONY: help
-help:
-	@echo "[default]      Equivalent to 'make preview'"
-	@echo "preview        Generate asciidoctor output (faster)"
-	@echo "build          Generate ccutil and asciidoctor output (slower)"
-	@echo "test           Run all build scripts and output checks"
-	@echo "clean          Removes ${BUILD_DIR}/ and other build artifacts"
-	@echo "publish        Copy output to http://file.rdu.redhat.com/~<user>/amq-docs/"
-	@echo
-	@echo "Preview and build render the output to ${BUILD_DIR}/"
-
-.PHONY: preview
-preview: ${BOOK_TARGETS} ${IMAGE_TARGETS} ${EXTRA_TARGETS}
-	@echo "See the output in your browser at file:${PWD}/${BUILD_DIR}/welcome/index.html"
-
-.PHONY: build
-build: preview ${CCUTIL_TARGETS}
-
-.PHONY: test
-test: clean build test-ccs-build
-
-.PHONY: clean
-clean: ${BOOK_SOURCES:%/master.adoc=clean-%}
-	rm -rf ${BUILD_DIR}
-
-.PHONY: publish
-publish: PUBLISH_DIR := amq-docs
 publish: build
-	rsync -av ${BUILD_DIR}/ file.rdu.redhat.com:public_html/${PUBLISH_DIR}
+	rsync -av html/ $(PUBLISH_DEST)
 
-.PHONY: test-ccs-build
-test-ccs-build:
-	scripts/buildGuides.sh
 
-define BOOK_TEMPLATE =
-$${BUILD_DIR}/${1}/index.html: $$(shell find -L ${1} -type f -name \*.adoc) common/attributes.adoc
-	@mkdir -p $${@D}
-	asciidoctor ${PREVIEW_ATTRIBUTES} -o $$@ ${1}/master.adoc
-
-$${BUILD_DIR}/${1}/images:
-	@mkdir -p $${@D}
-	ln -s ../images $$@
-
-$${BUILD_DIR}/ccutil/${1}/index.html:
-	@mkdir -p $${BUILD_DIR}/ccutil
-	cd ${1} && ccutil compile --lang en_US --main-file master.adoc
-	mv ${1}/build/tmp/en-US/html-single $${@D}
-	rm -rf ${1}/build
-
-.PHONY: clean-${1}
-clean-${1}:
-	rm -rf ${1}/build ${1}/html
-endef
-
-$(foreach dir,${BOOK_SOURCES:%/master.adoc=%},$(eval $(call BOOK_TEMPLATE,${dir})))
-
-${BUILD_DIR}/internal/%.html: internal/%.adoc common/attributes.adoc
-	@mkdir -p ${@D}
-	asciidoctor -o $@ $<
-
-${BUILD_DIR}/images/%.png: images/%.png
-	@mkdir -p ${@D}
-	cp $< $@
-
-${BUILD_DIR}/docs:
-	ln -s . $@
-
-.PHONY: ${BUILD_DIR}/index.html
-${BUILD_DIR}/index.html: scripts/redirect-to-welcome.html
-	cp $< $@
-
-.PHONY: refresh-upstream-%
-refresh-upstream-%: BRANCH := master
-refresh-upstream-%:
-	rm -rf upstream/$* upstream/$*.revision
-	scripts/git-export "https://github.com/strimzi/strimzi-kafka-operator.git" ${BRANCH} upstream/$*
+.PHONY: clean check generator build

--- a/Makefile.os
+++ b/Makefile.os
@@ -1,0 +1,12 @@
+FIND = find
+SED = sed
+GREP = grep
+CP = cp
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+	FIND = gfind
+	SED = gsed
+	GREP = ggrep
+	CP = gcp
+endif

--- a/generator/Makefile
+++ b/generator/Makefile
@@ -1,17 +1,53 @@
+TOOL=target/amq-streams-docs-0.1.0-SNAPSHOT.jar
+CONFIG_DOCS=ref-broker-config.adoc ref-consumer-config.adoc ref-producer-config.adoc ref-admin-client-config.adoc ref-connect-config.adoc ref-streams-config.adoc ref-topic-config.adoc
+METRICS_DOCS=ref-mbeans-producer-gen.adoc ref-mbeans-consumer-gen.adoc ref-mbeans-kafka-connect-gen.adoc ref-mbeans-kafka-streams-gen.adoc
 
 clean:
 	mvn clean
+	rm *.adoc
 
-jar:
+$(TOOL):
 	mvn install
 
-docs: jar
-	./configs.sh "Broker configuration parameters" broker > ../books/ref-broker-config.adoc
-	./configs.sh "Consumer configuration parameters" consumer > ../books/ref-consumer-config.adoc
-	./configs.sh "Producer configuration parameters" producer > ../books/ref-producer-config.adoc
-	./configs.sh "Admin Client configuration parameters" adminclient > ../books/ref-admin-client-config.adoc
-	./configs.sh "Kafka Connect configuration parameters" connect > ../books/ref-connect-config.adoc
-	./configs.sh "Kafka Streams configuration parameters" streams > ../books/ref-streams-config.adoc
-	./configs.sh "Topic configuration parameters" topic > ../books/ref-topic-config.adoc
+jar: $(TOOL)
 
-	./metrics.sh
+ref-broker-config.adoc: jar
+	./configs.sh "Broker configuration parameters" broker > ref-broker-config.adoc
+
+ref-consumer-config.adoc: jar
+	./configs.sh "Consumer configuration parameters" consumer > ref-consumer-config.adoc
+
+ref-producer-config.adoc: jar
+	./configs.sh "Producer configuration parameters" producer > ref-producer-config.adoc
+
+ref-admin-client-config.adoc: jar
+	./configs.sh "Admin Client configuration parameters" adminclient > ref-admin-client-config.adoc
+
+ref-connect-config.adoc: jar
+	./configs.sh "Kafka Connect configuration parameters" connect > ref-connect-config.adoc
+
+ref-streams-config.adoc: jar
+	./configs.sh "Kafka Streams configuration parameters" streams > ref-streams-config.adoc
+
+ref-topic-config.adoc: jar
+	./configs.sh "Topic configuration parameters" topic > ref-topic-config.adoc
+
+configs: $(CONFIG_DOCS)
+
+ref-mbeans-producer-gen.adoc: jar
+	./metrics.sh producer ref-mbeans-producer-gen.adoc
+
+ref-mbeans-consumer-gen.adoc: jar
+	./metrics.sh consumer ref-mbeans-consumer-gen.adoc
+
+ref-mbeans-kafka-connect-gen.adoc: jar
+	./metrics.sh connect ref-mbeans-kafka-connect-gen.adoc
+
+ref-mbeans-kafka-streams-gen.adoc: jar
+	./metrics.sh streams ref-mbeans-kafka-streams-gen.adoc
+
+metrics: $(METRICS_DOCS)
+
+docs: configs metrics
+
+.PHONY: clean jar configs docs

--- a/generator/Makefile
+++ b/generator/Makefile
@@ -1,53 +1,53 @@
 TOOL=target/amq-streams-docs-0.1.0-SNAPSHOT.jar
-CONFIG_DOCS=ref-broker-config.adoc ref-consumer-config.adoc ref-producer-config.adoc ref-admin-client-config.adoc ref-connect-config.adoc ref-streams-config.adoc ref-topic-config.adoc
-METRICS_DOCS=ref-mbeans-producer-gen.adoc ref-mbeans-consumer-gen.adoc ref-mbeans-kafka-connect-gen.adoc ref-mbeans-kafka-streams-gen.adoc
+CONFIG_DOCS=$(wildcard ref-*-config.adoc)
+METRICS_DOCS=$(wildcard ref-mbeans-*-gen.adoc)
+JAVA_FILES:=$(shell find src/main/java/ -type f -name '*.java')
+
+docs: configs metrics
 
 clean:
 	mvn clean
-	rm *.adoc
+	rm $(CONFIG_DOCS)
+	rm $(METRICS_DOCS)
 
-$(TOOL):
+$(TOOL): pom.xml $(JAVA_FILES)
 	mvn install
 
-jar: $(TOOL)
-
-ref-broker-config.adoc: jar
+ref-broker-config.adoc: configs.sh $(TOOL)
 	./configs.sh "Broker configuration parameters" broker > ref-broker-config.adoc
 
-ref-consumer-config.adoc: jar
+ref-consumer-config.adoc: configs.sh $(TOOL)
 	./configs.sh "Consumer configuration parameters" consumer > ref-consumer-config.adoc
 
-ref-producer-config.adoc: jar
+ref-producer-config.adoc: configs.sh $(TOOL)
 	./configs.sh "Producer configuration parameters" producer > ref-producer-config.adoc
 
-ref-admin-client-config.adoc: jar
+ref-admin-client-config.adoc: configs.sh $(TOOL)
 	./configs.sh "Admin Client configuration parameters" adminclient > ref-admin-client-config.adoc
 
-ref-connect-config.adoc: jar
+ref-connect-config.adoc: configs.sh $(TOOL)
 	./configs.sh "Kafka Connect configuration parameters" connect > ref-connect-config.adoc
 
-ref-streams-config.adoc: jar
+ref-streams-config.adoc: configs.sh $(TOOL)
 	./configs.sh "Kafka Streams configuration parameters" streams > ref-streams-config.adoc
 
-ref-topic-config.adoc: jar
+ref-topic-config.adoc: configs.sh $(TOOL)
 	./configs.sh "Topic configuration parameters" topic > ref-topic-config.adoc
 
 configs: $(CONFIG_DOCS)
 
-ref-mbeans-producer-gen.adoc: jar
+ref-mbeans-producer-gen.adoc: metrics.sh $(TOOL)
 	./metrics.sh producer ref-mbeans-producer-gen.adoc
 
-ref-mbeans-consumer-gen.adoc: jar
+ref-mbeans-consumer-gen.adoc: metrics.sh $(TOOL)
 	./metrics.sh consumer ref-mbeans-consumer-gen.adoc
 
-ref-mbeans-kafka-connect-gen.adoc: jar
+ref-mbeans-kafka-connect-gen.adoc: metrics.sh $(TOOL)
 	./metrics.sh connect ref-mbeans-kafka-connect-gen.adoc
 
-ref-mbeans-kafka-streams-gen.adoc: jar
+ref-mbeans-kafka-streams-gen.adoc: metrics.sh $(TOOL)
 	./metrics.sh streams ref-mbeans-kafka-streams-gen.adoc
 
 metrics: $(METRICS_DOCS)
 
-docs: configs metrics
-
-.PHONY: clean jar configs docs
+.PHONY: clean configs metrics docs

--- a/generator/Makefile
+++ b/generator/Makefile
@@ -1,6 +1,6 @@
 TOOL=target/amq-streams-docs-0.1.0-SNAPSHOT.jar
-CONFIG_DOCS=$(wildcard ref-*-config.adoc)
-METRICS_DOCS=$(wildcard ref-mbeans-*-gen.adoc)
+CONFIG_DOCS=ref-broker-config.adoc ref-consumer-config.adoc ref-producer-config.adoc ref-admin-client-config.adoc ref-connect-config.adoc ref-streams-config.adoc ref-topic-config.adoc
+METRICS_DOCS=ref-mbeans-producer-gen.adoc ref-mbeans-consumer-gen.adoc ref-mbeans-kafka-connect-gen.adoc ref-mbeans-kafka-streams-gen.adoc
 JAVA_FILES:=$(shell find src/main/java/ -type f -name '*.java')
 
 docs: configs metrics
@@ -50,4 +50,4 @@ ref-mbeans-kafka-streams-gen.adoc: metrics.sh $(TOOL)
 
 metrics: $(METRICS_DOCS)
 
-.PHONY: clean configs metrics docs
+.PHONY: docs clean configs metrics 

--- a/generator/metrics.sh
+++ b/generator/metrics.sh
@@ -204,7 +204,17 @@ $(metrics           'kafka.streams:type=stream-record-cache-metrics,client-id=*,
 EOF
 }
 
-adoc ../books/ref-mbeans-producer-gen.adoc "Producer MBeans" "$(producer)"
-adoc ../books/ref-mbeans-consumer-gen.adoc "Consumer MBeans" "$(consumer)"
-adoc ../books/ref-mbeans-kafka-connect-gen.adoc "Kafka Connect MBeans" "$(connect)"
-adoc ../books/ref-mbeans-kafka-streams-gen.adoc "Kafka Streams MBeans" "$(streams)"
+case $1 in
+    producer)
+    adoc $2 "Producer MBeans" "$(producer)"
+    ;;
+    consumer)
+    adoc $2 "Consumer MBeans" "$(consumer)"
+    ;;
+    connect)
+    adoc $2 "Kafka Connect MBeans" "$(connect)"
+    ;;
+    streams)
+    adoc $2 "Kafka Streams MBeans" "$(streams)"
+    ;;
+esac


### PR DESCRIPTION
This PR provides a usable set of `make` targets, as follows:

* `make clean`: Delete all temporary files
* `make check`: Execute the custom checks in `.travis/check_docs.sh`
* `make build`: Build the docs using asciidoc, excluding the generated documentation
* `make buildall`: Build the docs using asciidoc, including the generated documentation (requires [`mvn`](https://maven.apache.org/)).
* `make publish`: Build the docs via `make build` and publish them using `rsync`. The publish destiniation is configured via a `Makefile.publish` (not included in this PR; provided by each user so they can publish to their own location). The `Makefile.publish` needs to configure a single `PUBLISH_DEST` variable which is the remote directory (`<host>:<dir>`) to copy the generated docs to. 


