### PR TITLE
Use a definition list for generated config docs

### DIFF
--- a/books/ref-admin-client-config.adoc
+++ b/books/ref-admin-client-config.adoc
@@ -1,327 +1,338 @@
 // Module included in the following assemblies:
 //
 // assembly-overview.adoc
+//
+// THIS FILE IS AUTO-GENERATED. DO NOT EDIT BY HAND
+// Run "make clean buildall" to regenerate.
 
 [id='admin-client-configuration-parameters-{context}']
 = Admin Client configuration parameters
 
-[cols="6",options="header",separator=¦]
-|=====
-¦Name ¦Description ¦Type ¦Default ¦Valid Values ¦Importance 
+`bootstrap.servers`::
+*Type:* list +
+*Importance:* high +
++
+A list of host/port pairs to use for establishing the initial connection to the Kafka cluster. The client will make use of all servers irrespective of which servers are specified here for bootstrapping&mdash;this list only impacts the initial hosts used to discover the full set of servers. This list should be in the form `host1:port1,host2:port2,...`. Since these servers are just used for the initial connection to discover the full cluster membership (which may change dynamically), this list need not contain the full set of servers (you may want more than one, though, in case a server is down).
 
-¦`bootstrap.servers`
-a¦A list of host/port pairs to use for establishing the initial connection to the Kafka cluster. The client will make use of all servers irrespective of which servers are specified here for bootstrapping&mdash;this list only impacts the initial hosts used to discover the full set of servers. This list should be in the form `host1:port1,host2:port2,...`. Since these servers are just used for the initial connection to discover the full cluster membership (which may change dynamically), this list need not contain the full set of servers (you may want more than one, though, in case a server is down).
-¦list
-¦
-¦
-¦high
+`ssl.key.password`::
+*Type:* password +
+*Default:* null +
+*Importance:* high +
++
+The password of the private key in the key store file. This is optional for client.
 
-¦`ssl.key.password`
-a¦The password of the private key in the key store file. This is optional for client.
-¦password
-¦null
-¦
-¦high
+`ssl.keystore.location`::
+*Type:* string +
+*Default:* null +
+*Importance:* high +
++
+The location of the key store file. This is optional for client and can be used for two-way authentication for client.
 
-¦`ssl.keystore.location`
-a¦The location of the key store file. This is optional for client and can be used for two-way authentication for client.
-¦string
-¦null
-¦
-¦high
+`ssl.keystore.password`::
+*Type:* password +
+*Default:* null +
+*Importance:* high +
++
+The store password for the key store file. This is optional for client and only needed if ssl.keystore.location is configured.
 
-¦`ssl.keystore.password`
-a¦The store password for the key store file. This is optional for client and only needed if ssl.keystore.location is configured. 
-¦password
-¦null
-¦
-¦high
+`ssl.truststore.location`::
+*Type:* string +
+*Default:* null +
+*Importance:* high +
++
+The location of the trust store file.
 
-¦`ssl.truststore.location`
-a¦The location of the trust store file. 
-¦string
-¦null
-¦
-¦high
+`ssl.truststore.password`::
+*Type:* password +
+*Default:* null +
+*Importance:* high +
++
+The password for the trust store file. If a password is not set access to the truststore is still available, but integrity checking is disabled.
 
-¦`ssl.truststore.password`
-a¦The password for the trust store file. If a password is not set access to the truststore is still available, but integrity checking is disabled.
-¦password
-¦null
-¦
-¦high
+`client.id`::
+*Type:* string +
+*Default:* "" +
+*Importance:* medium +
++
+An id string to pass to the server when making requests. The purpose of this is to be able to track the source of requests beyond just ip/port by allowing a logical application name to be included in server-side request logging.
 
-¦`client.id`
-a¦An id string to pass to the server when making requests. The purpose of this is to be able to track the source of requests beyond just ip/port by allowing a logical application name to be included in server-side request logging.
-¦string
-¦""
-¦
-¦medium
+`connections.max.idle.ms`::
+*Type:* long +
+*Default:* 300000 +
+*Importance:* medium +
++
+Close idle connections after the number of milliseconds specified by this config.
 
-¦`connections.max.idle.ms`
-a¦Close idle connections after the number of milliseconds specified by this config.
-¦long
-¦300000
-¦
-¦medium
+`receive.buffer.bytes`::
+*Type:* int +
+*Default:* 65536 +
+*Valid Values:* [-1,...] +
+*Importance:* medium +
++
+The size of the TCP receive buffer (SO_RCVBUF) to use when reading data. If the value is -1, the OS default will be used.
 
-¦`receive.buffer.bytes`
-a¦The size of the TCP receive buffer (SO_RCVBUF) to use when reading data. If the value is -1, the OS default will be used.
-¦int
-¦65536
-¦[-1,...]
-¦medium
+`request.timeout.ms`::
+*Type:* int +
+*Default:* 120000 +
+*Valid Values:* [0,...] +
+*Importance:* medium +
++
+The configuration controls the maximum amount of time the client will wait for the response of a request. If the response is not received before the timeout elapses the client will resend the request if necessary or fail the request if retries are exhausted.
 
-¦`request.timeout.ms`
-a¦The configuration controls the maximum amount of time the client will wait for the response of a request. If the response is not received before the timeout elapses the client will resend the request if necessary or fail the request if retries are exhausted.
-¦int
-¦120000
-¦[0,...]
-¦medium
+`sasl.client.callback.handler.class`::
+*Type:* class +
+*Default:* null +
+*Importance:* medium +
++
+The fully qualified name of a SASL client callback handler class that implements the AuthenticateCallbackHandler interface.
 
-¦`sasl.client.callback.handler.class`
-a¦The fully qualified name of a SASL client callback handler class that implements the AuthenticateCallbackHandler interface.
-¦class
-¦null
-¦
-¦medium
+`sasl.jaas.config`::
+*Type:* password +
+*Default:* null +
+*Importance:* medium +
++
+JAAS login context parameters for SASL connections in the format used by JAAS configuration files. JAAS configuration file format is described http://docs.oracle.com/javase/8/docs/technotes/guides/security/jgss/tutorials/LoginConfigFile.html[here]. The format for the value is: '`loginModuleClass controlFlag (optionName=optionValue)*;`'. For brokers, the config must be prefixed with listener prefix and SASL mechanism name in lower-case. For example, listener.name.sasl_ssl.scram-sha-256.sasl.jaas.config=com.example.ScramLoginModule required;.
 
-¦`sasl.jaas.config`
-a¦JAAS login context parameters for SASL connections in the format used by JAAS configuration files. JAAS configuration file format is described http://docs.oracle.com/javase/8/docs/technotes/guides/security/jgss/tutorials/LoginConfigFile.html[here]. The format for the value is: '`loginModuleClass controlFlag (optionName=optionValue)*;`'. For brokers, the config must be prefixed with listener prefix and SASL mechanism name in lower-case. For example, listener.name.sasl_ssl.scram-sha-256.sasl.jaas.config=com.example.ScramLoginModule required;
-¦password
-¦null
-¦
-¦medium
+`sasl.kerberos.service.name`::
+*Type:* string +
+*Default:* null +
+*Importance:* medium +
++
+The Kerberos principal name that Kafka runs as. This can be defined either in Kafka's JAAS config or in Kafka's config.
 
-¦`sasl.kerberos.service.name`
-a¦The Kerberos principal name that Kafka runs as. This can be defined either in Kafka's JAAS config or in Kafka's config.
-¦string
-¦null
-¦
-¦medium
+`sasl.login.callback.handler.class`::
+*Type:* class +
+*Default:* null +
+*Importance:* medium +
++
+The fully qualified name of a SASL login callback handler class that implements the AuthenticateCallbackHandler interface. For brokers, login callback handler config must be prefixed with listener prefix and SASL mechanism name in lower-case. For example, listener.name.sasl_ssl.scram-sha-256.sasl.login.callback.handler.class=com.example.CustomScramLoginCallbackHandler.
 
-¦`sasl.login.callback.handler.class`
-a¦The fully qualified name of a SASL login callback handler class that implements the AuthenticateCallbackHandler interface. For brokers, login callback handler config must be prefixed with listener prefix and SASL mechanism name in lower-case. For example, listener.name.sasl_ssl.scram-sha-256.sasl.login.callback.handler.class=com.example.CustomScramLoginCallbackHandler
-¦class
-¦null
-¦
-¦medium
+`sasl.login.class`::
+*Type:* class +
+*Default:* null +
+*Importance:* medium +
++
+The fully qualified name of a class that implements the Login interface. For brokers, login config must be prefixed with listener prefix and SASL mechanism name in lower-case. For example, listener.name.sasl_ssl.scram-sha-256.sasl.login.class=com.example.CustomScramLogin.
 
-¦`sasl.login.class`
-a¦The fully qualified name of a class that implements the Login interface. For brokers, login config must be prefixed with listener prefix and SASL mechanism name in lower-case. For example, listener.name.sasl_ssl.scram-sha-256.sasl.login.class=com.example.CustomScramLogin
-¦class
-¦null
-¦
-¦medium
+`sasl.mechanism`::
+*Type:* string +
+*Default:* GSSAPI +
+*Importance:* medium +
++
+SASL mechanism used for client connections. This may be any mechanism for which a security provider is available. GSSAPI is the default mechanism.
 
-¦`sasl.mechanism`
-a¦SASL mechanism used for client connections. This may be any mechanism for which a security provider is available. GSSAPI is the default mechanism.
-¦string
-¦GSSAPI
-¦
-¦medium
+`security.protocol`::
+*Type:* string +
+*Default:* PLAINTEXT +
+*Importance:* medium +
++
+Protocol used to communicate with brokers. Valid values are: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL.
 
-¦`security.protocol`
-a¦Protocol used to communicate with brokers. Valid values are: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL.
-¦string
-¦PLAINTEXT
-¦
-¦medium
+`send.buffer.bytes`::
+*Type:* int +
+*Default:* 131072 +
+*Valid Values:* [-1,...] +
+*Importance:* medium +
++
+The size of the TCP send buffer (SO_SNDBUF) to use when sending data. If the value is -1, the OS default will be used.
 
-¦`send.buffer.bytes`
-a¦The size of the TCP send buffer (SO_SNDBUF) to use when sending data. If the value is -1, the OS default will be used.
-¦int
-¦131072
-¦[-1,...]
-¦medium
+`ssl.enabled.protocols`::
+*Type:* list +
+*Default:* TLSv1.2,TLSv1.1,TLSv1 +
+*Importance:* medium +
++
+The list of protocols enabled for SSL connections.
 
-¦`ssl.enabled.protocols`
-a¦The list of protocols enabled for SSL connections.
-¦list
-¦TLSv1.2,TLSv1.1,TLSv1
-¦
-¦medium
+`ssl.keystore.type`::
+*Type:* string +
+*Default:* JKS +
+*Importance:* medium +
++
+The file format of the key store file. This is optional for client.
 
-¦`ssl.keystore.type`
-a¦The file format of the key store file. This is optional for client.
-¦string
-¦JKS
-¦
-¦medium
+`ssl.protocol`::
+*Type:* string +
+*Default:* TLS +
+*Importance:* medium +
++
+The SSL protocol used to generate the SSLContext. Default setting is TLS, which is fine for most cases. Allowed values in recent JVMs are TLS, TLSv1.1 and TLSv1.2. SSL, SSLv2 and SSLv3 may be supported in older JVMs, but their usage is discouraged due to known security vulnerabilities.
 
-¦`ssl.protocol`
-a¦The SSL protocol used to generate the SSLContext. Default setting is TLS, which is fine for most cases. Allowed values in recent JVMs are TLS, TLSv1.1 and TLSv1.2. SSL, SSLv2 and SSLv3 may be supported in older JVMs, but their usage is discouraged due to known security vulnerabilities.
-¦string
-¦TLS
-¦
-¦medium
+`ssl.provider`::
+*Type:* string +
+*Default:* null +
+*Importance:* medium +
++
+The name of the security provider used for SSL connections. Default value is the default security provider of the JVM.
 
-¦`ssl.provider`
-a¦The name of the security provider used for SSL connections. Default value is the default security provider of the JVM.
-¦string
-¦null
-¦
-¦medium
+`ssl.truststore.type`::
+*Type:* string +
+*Default:* JKS +
+*Importance:* medium +
++
+The file format of the trust store file.
 
-¦`ssl.truststore.type`
-a¦The file format of the trust store file.
-¦string
-¦JKS
-¦
-¦medium
+`metadata.max.age.ms`::
+*Type:* long +
+*Default:* 300000 +
+*Valid Values:* [0,...] +
+*Importance:* low +
++
+The period of time in milliseconds after which we force a refresh of metadata even if we haven't seen any partition leadership changes to proactively discover any new brokers or partitions.
 
-¦`metadata.max.age.ms`
-a¦The period of time in milliseconds after which we force a refresh of metadata even if we haven't seen any partition leadership changes to proactively discover any new brokers or partitions.
-¦long
-¦300000
-¦[0,...]
-¦low
+`metric.reporters`::
+*Type:* list +
+*Default:* "" +
+*Importance:* low +
++
+A list of classes to use as metrics reporters. Implementing the `org.apache.kafka.common.metrics.MetricsReporter` interface allows plugging in classes that will be notified of new metric creation. The JmxReporter is always included to register JMX statistics.
 
-¦`metric.reporters`
-a¦A list of classes to use as metrics reporters. Implementing the `org.apache.kafka.common.metrics.MetricsReporter` interface allows plugging in classes that will be notified of new metric creation. The JmxReporter is always included to register JMX statistics.
-¦list
-¦""
-¦
-¦low
+`metrics.num.samples`::
+*Type:* int +
+*Default:* 2 +
+*Valid Values:* [1,...] +
+*Importance:* low +
++
+The number of samples maintained to compute metrics.
 
-¦`metrics.num.samples`
-a¦The number of samples maintained to compute metrics.
-¦int
-¦2
-¦[1,...]
-¦low
+`metrics.recording.level`::
+*Type:* string +
+*Default:* INFO +
+*Valid Values:* [INFO, DEBUG] +
+*Importance:* low +
++
+The highest recording level for metrics.
 
-¦`metrics.recording.level`
-a¦The highest recording level for metrics.
-¦string
-¦INFO
-¦[INFO, DEBUG]
-¦low
+`metrics.sample.window.ms`::
+*Type:* long +
+*Default:* 30000 +
+*Valid Values:* [0,...] +
+*Importance:* low +
++
+The window of time a metrics sample is computed over.
 
-¦`metrics.sample.window.ms`
-a¦The window of time a metrics sample is computed over.
-¦long
-¦30000
-¦[0,...]
-¦low
+`reconnect.backoff.max.ms`::
+*Type:* long +
+*Default:* 1000 +
+*Valid Values:* [0,...] +
+*Importance:* low +
++
+The maximum amount of time in milliseconds to wait when reconnecting to a broker that has repeatedly failed to connect. If provided, the backoff per host will increase exponentially for each consecutive connection failure, up to this maximum. After calculating the backoff increase, 20% random jitter is added to avoid connection storms.
 
-¦`reconnect.backoff.max.ms`
-a¦The maximum amount of time in milliseconds to wait when reconnecting to a broker that has repeatedly failed to connect. If provided, the backoff per host will increase exponentially for each consecutive connection failure, up to this maximum. After calculating the backoff increase, 20% random jitter is added to avoid connection storms.
-¦long
-¦1000
-¦[0,...]
-¦low
+`reconnect.backoff.ms`::
+*Type:* long +
+*Default:* 50 +
+*Valid Values:* [0,...] +
+*Importance:* low +
++
+The base amount of time to wait before attempting to reconnect to a given host. This avoids repeatedly connecting to a host in a tight loop. This backoff applies to all connection attempts by the client to a broker.
 
-¦`reconnect.backoff.ms`
-a¦The base amount of time to wait before attempting to reconnect to a given host. This avoids repeatedly connecting to a host in a tight loop. This backoff applies to all connection attempts by the client to a broker.
-¦long
-¦50
-¦[0,...]
-¦low
+`retries`::
+*Type:* int +
+*Default:* 5 +
+*Valid Values:* [0,...] +
+*Importance:* low +
++
+Setting a value greater than zero will cause the client to resend any request that fails with a potentially transient error.
 
-¦`retries`
-a¦Setting a value greater than zero will cause the client to resend any request that fails with a potentially transient error.
-¦int
-¦5
-¦[0,...]
-¦low
+`retry.backoff.ms`::
+*Type:* long +
+*Default:* 100 +
+*Valid Values:* [0,...] +
+*Importance:* low +
++
+The amount of time to wait before attempting to retry a failed request. This avoids repeatedly sending requests in a tight loop under some failure scenarios.
 
-¦`retry.backoff.ms`
-a¦The amount of time to wait before attempting to retry a failed request. This avoids repeatedly sending requests in a tight loop under some failure scenarios.
-¦long
-¦100
-¦[0,...]
-¦low
+`sasl.kerberos.kinit.cmd`::
+*Type:* string +
+*Default:* /usr/bin/kinit +
+*Importance:* low +
++
+Kerberos kinit command path.
 
-¦`sasl.kerberos.kinit.cmd`
-a¦Kerberos kinit command path.
-¦string
-¦/usr/bin/kinit
-¦
-¦low
+`sasl.kerberos.min.time.before.relogin`::
+*Type:* long +
+*Default:* 60000 +
+*Importance:* low +
++
+Login thread sleep time between refresh attempts.
 
-¦`sasl.kerberos.min.time.before.relogin`
-a¦Login thread sleep time between refresh attempts.
-¦long
-¦60000
-¦
-¦low
+`sasl.kerberos.ticket.renew.jitter`::
+*Type:* double +
+*Default:* 0.05 +
+*Importance:* low +
++
+Percentage of random jitter added to the renewal time.
 
-¦`sasl.kerberos.ticket.renew.jitter`
-a¦Percentage of random jitter added to the renewal time.
-¦double
-¦0.05
-¦
-¦low
+`sasl.kerberos.ticket.renew.window.factor`::
+*Type:* double +
+*Default:* 0.8 +
+*Importance:* low +
++
+Login thread will sleep until the specified window factor of time from last refresh to ticket's expiry has been reached, at which time it will try to renew the ticket.
 
-¦`sasl.kerberos.ticket.renew.window.factor`
-a¦Login thread will sleep until the specified window factor of time from last refresh to ticket's expiry has been reached, at which time it will try to renew the ticket.
-¦double
-¦0.8
-¦
-¦low
+`sasl.login.refresh.buffer.seconds`::
+*Type:* short +
+*Default:* 300 +
+*Valid Values:* [0,...,3600] +
+*Importance:* low +
++
+The amount of buffer time before credential expiration to maintain when refreshing a credential, in seconds. If a refresh would otherwise occur closer to expiration than the number of buffer seconds then the refresh will be moved up to maintain as much of the buffer time as possible. Legal values are between 0 and 3600 (1 hour); a default value of  300 (5 minutes) is used if no value is specified. This value and sasl.login.refresh.min.period.seconds are both ignored if their sum exceeds the remaining lifetime of a credential. Currently applies only to OAUTHBEARER.
 
-¦`sasl.login.refresh.buffer.seconds`
-a¦The amount of buffer time before credential expiration to maintain when refreshing a credential, in seconds. If a refresh would otherwise occur closer to expiration than the number of buffer seconds then the refresh will be moved up to maintain as much of the buffer time as possible. Legal values are between 0 and 3600 (1 hour); a default value of  300 (5 minutes) is used if no value is specified. This value and sasl.login.refresh.min.period.seconds are both ignored if their sum exceeds the remaining lifetime of a credential. Currently applies only to OAUTHBEARER.
-¦short
-¦300
-¦[0,...,3600]
-¦low
+`sasl.login.refresh.min.period.seconds`::
+*Type:* short +
+*Default:* 60 +
+*Valid Values:* [0,...,900] +
+*Importance:* low +
++
+The desired minimum time for the login refresh thread to wait before refreshing a credential, in seconds. Legal values are between 0 and 900 (15 minutes); a default value of 60 (1 minute) is used if no value is specified.  This value and  sasl.login.refresh.buffer.seconds are both ignored if their sum exceeds the remaining lifetime of a credential. Currently applies only to OAUTHBEARER.
 
-¦`sasl.login.refresh.min.period.seconds`
-a¦The desired minimum time for the login refresh thread to wait before refreshing a credential, in seconds. Legal values are between 0 and 900 (15 minutes); a default value of 60 (1 minute) is used if no value is specified.  This value and  sasl.login.refresh.buffer.seconds are both ignored if their sum exceeds the remaining lifetime of a credential. Currently applies only to OAUTHBEARER.
-¦short
-¦60
-¦[0,...,900]
-¦low
+`sasl.login.refresh.window.factor`::
+*Type:* double +
+*Default:* 0.8 +
+*Valid Values:* [0.5,...,1.0] +
+*Importance:* low +
++
+Login refresh thread will sleep until the specified window factor relative to the credential's lifetime has been reached, at which time it will try to refresh the credential. Legal values are between 0.5 (50%) and 1.0 (100%) inclusive; a default value of 0.8 (80%) is used if no value is specified. Currently applies only to OAUTHBEARER.
 
-¦`sasl.login.refresh.window.factor`
-a¦Login refresh thread will sleep until the specified window factor relative to the credential's lifetime has been reached, at which time it will try to refresh the credential. Legal values are between 0.5 (50%) and 1.0 (100%) inclusive; a default value of 0.8 (80%) is used if no value is specified. Currently applies only to OAUTHBEARER.
-¦double
-¦0.8
-¦[0.5,...,1.0]
-¦low
+`sasl.login.refresh.window.jitter`::
+*Type:* double +
+*Default:* 0.05 +
+*Valid Values:* [0.0,...,0.25] +
+*Importance:* low +
++
+The maximum amount of random jitter relative to the credential's lifetime that is added to the login refresh thread's sleep time. Legal values are between 0 and 0.25 (25%) inclusive; a default value of 0.05 (5%) is used if no value is specified. Currently applies only to OAUTHBEARER.
 
-¦`sasl.login.refresh.window.jitter`
-a¦The maximum amount of random jitter relative to the credential's lifetime that is added to the login refresh thread's sleep time. Legal values are between 0 and 0.25 (25%) inclusive; a default value of 0.05 (5%) is used if no value is specified. Currently applies only to OAUTHBEARER.
-¦double
-¦0.05
-¦[0.0,...,0.25]
-¦low
+`ssl.cipher.suites`::
+*Type:* list +
+*Default:* null +
+*Importance:* low +
++
+A list of cipher suites. This is a named combination of authentication, encryption, MAC and key exchange algorithm used to negotiate the security settings for a network connection using TLS or SSL network protocol. By default all the available cipher suites are supported.
 
-¦`ssl.cipher.suites`
-a¦A list of cipher suites. This is a named combination of authentication, encryption, MAC and key exchange algorithm used to negotiate the security settings for a network connection using TLS or SSL network protocol. By default all the available cipher suites are supported.
-¦list
-¦null
-¦
-¦low
+`ssl.endpoint.identification.algorithm`::
+*Type:* string +
+*Default:* https +
+*Importance:* low +
++
+The endpoint identification algorithm to validate server hostname using server certificate.
 
-¦`ssl.endpoint.identification.algorithm`
-a¦The endpoint identification algorithm to validate server hostname using server certificate. 
-¦string
-¦https
-¦
-¦low
+`ssl.keymanager.algorithm`::
+*Type:* string +
+*Default:* SunX509 +
+*Importance:* low +
++
+The algorithm used by key manager factory for SSL connections. Default value is the key manager factory algorithm configured for the Java Virtual Machine.
 
-¦`ssl.keymanager.algorithm`
-a¦The algorithm used by key manager factory for SSL connections. Default value is the key manager factory algorithm configured for the Java Virtual Machine.
-¦string
-¦SunX509
-¦
-¦low
+`ssl.secure.random.implementation`::
+*Type:* string +
+*Default:* null +
+*Importance:* low +
++
+The SecureRandom PRNG implementation to use for SSL cryptography operations.
 
-¦`ssl.secure.random.implementation`
-a¦The SecureRandom PRNG implementation to use for SSL cryptography operations. 
-¦string
-¦null
-¦
-¦low
-
-¦`ssl.trustmanager.algorithm`
-a¦The algorithm used by trust manager factory for SSL connections. Default value is the trust manager factory algorithm configured for the Java Virtual Machine.
-¦string
-¦PKIX
-¦
-¦low
-
-|=====
+`ssl.trustmanager.algorithm`::
+*Type:* string +
+*Default:* PKIX +
+*Importance:* low +
++
+The algorithm used by trust manager factory for SSL connections. Default value is the trust manager factory algorithm configured for the Java Virtual Machine.

--- a/books/ref-broker-config.adoc
+++ b/books/ref-broker-config.adoc
@@ -1,1302 +1,1542 @@
 // Module included in the following assemblies:
 //
 // assembly-overview.adoc
+//
+// THIS FILE IS AUTO-GENERATED. DO NOT EDIT BY HAND
+// Run "make clean buildall" to regenerate.
 
 [id='broker-configuration-parameters-{context}']
 = Broker configuration parameters
 
-[cols="6",options="header",separator=¦]
-|=====
-¦Name ¦Description ¦Type ¦Default ¦Valid Values ¦Importance 
+`zookeeper.connect`::
+*Type:* string +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+Zookeeper host string.
 
-¦`zookeeper.connect`
-a¦Zookeeper host string
-¦string
-¦
-¦
-¦high
-
-¦`advertised.host.name`
-a¦DEPRECATED: only used when `advertised.listeners` or `listeners` are not set. Use `advertised.listeners` instead. 
+`advertised.host.name`::
+*Type:* string +
+*Default:* null +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+DEPRECATED: only used when `advertised.listeners` or `listeners` are not set. Use `advertised.listeners` instead. 
 Hostname to publish to ZooKeeper for clients to use. In IaaS environments, this may need to be different from the interface to which the broker binds. If this is not set, it will use the value for `host.name` if configured. Otherwise it will use the value returned from java.net.InetAddress.getCanonicalHostName().
-¦string
-¦null
-¦
-¦high
 
-¦`advertised.listeners`
-a¦Listeners to publish to ZooKeeper for clients to use, if different than the `listeners` config property. In IaaS environments, this may need to be different from the interface to which the broker binds. If this is not set, the value for `listeners` will be used. Unlike `listeners` it is not valid to advertise the 0.0.0.0 meta-address.
-¦string
-¦null
-¦
-¦high
+`advertised.listeners`::
+*Type:* string +
+*Default:* null +
+*Importance:* high +
+*Dynamic update:* per-broker +
++
+Listeners to publish to ZooKeeper for clients to use, if different than the `listeners` config property. In IaaS environments, this may need to be different from the interface to which the broker binds. If this is not set, the value for `listeners` will be used. Unlike `listeners` it is not valid to advertise the 0.0.0.0 meta-address.
 
-¦`advertised.port`
-a¦DEPRECATED: only used when `advertised.listeners` or `listeners` are not set. Use `advertised.listeners` instead. 
+`advertised.port`::
+*Type:* int +
+*Default:* null +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+DEPRECATED: only used when `advertised.listeners` or `listeners` are not set. Use `advertised.listeners` instead. 
 The port to publish to ZooKeeper for clients to use. In IaaS environments, this may need to be different from the port to which the broker binds. If this is not set, it will publish the same port that the broker binds to.
-¦int
-¦null
-¦
-¦high
 
-¦`auto.create.topics.enable`
-a¦Enable auto creation of topic on the server
-¦boolean
-¦true
-¦
-¦high
+`auto.create.topics.enable`::
+*Type:* boolean +
+*Default:* true +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+Enable auto creation of topic on the server.
 
-¦`auto.leader.rebalance.enable`
-a¦Enables auto leader balancing. A background thread checks and triggers leader balance if required at regular intervals
-¦boolean
-¦true
-¦
-¦high
+`auto.leader.rebalance.enable`::
+*Type:* boolean +
+*Default:* true +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+Enables auto leader balancing. A background thread checks and triggers leader balance if required at regular intervals.
 
-¦`background.threads`
-a¦The number of threads to use for various background processing tasks
-¦int
-¦10
-¦[1,...]
-¦high
+`background.threads`::
+*Type:* int +
+*Default:* 10 +
+*Valid Values:* [1,...] +
+*Importance:* high +
+*Dynamic update:* cluster-wide +
++
+The number of threads to use for various background processing tasks.
 
-¦`broker.id`
-a¦The broker id for this server. If unset, a unique broker id will be generated.To avoid conflicts between zookeeper generated broker id's and user configured broker id's, generated broker ids start from reserved.broker.max.id + 1.
-¦int
-¦-1
-¦
-¦high
+`broker.id`::
+*Type:* int +
+*Default:* -1 +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+The broker id for this server. If unset, a unique broker id will be generated.To avoid conflicts between zookeeper generated broker id's and user configured broker id's, generated broker ids start from reserved.broker.max.id + 1.
 
-¦`compression.type`
-a¦Specify the final compression type for a given topic. This configuration accepts the standard compression codecs ('gzip', 'snappy', 'lz4'). It additionally accepts 'uncompressed' which is equivalent to no compression; and 'producer' which means retain the original compression codec set by the producer.
-¦string
-¦producer
-¦
-¦high
+`compression.type`::
+*Type:* string +
+*Default:* producer +
+*Importance:* high +
+*Dynamic update:* cluster-wide +
++
+Specify the final compression type for a given topic. This configuration accepts the standard compression codecs ('gzip', 'snappy', 'lz4'). It additionally accepts 'uncompressed' which is equivalent to no compression; and 'producer' which means retain the original compression codec set by the producer.
 
-¦`delete.topic.enable`
-a¦Enables delete topic. Delete topic through the admin tool will have no effect if this config is turned off
-¦boolean
-¦true
-¦
-¦high
+`delete.topic.enable`::
+*Type:* boolean +
+*Default:* true +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+Enables delete topic. Delete topic through the admin tool will have no effect if this config is turned off.
 
-¦`host.name`
-a¦DEPRECATED: only used when `listeners` is not set. Use `listeners` instead. 
-hostname of broker. If this is set, it will only bind to this address. If this is not set, it will bind to all interfaces
-¦string
-¦""
-¦
-¦high
+`host.name`::
+*Type:* string +
+*Default:* "" +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+DEPRECATED: only used when `listeners` is not set. Use `listeners` instead. 
+hostname of broker. If this is set, it will only bind to this address. If this is not set, it will bind to all interfaces.
 
-¦`leader.imbalance.check.interval.seconds`
-a¦The frequency with which the partition rebalance check is triggered by the controller
-¦long
-¦300
-¦
-¦high
+`leader.imbalance.check.interval.seconds`::
+*Type:* long +
+*Default:* 300 +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+The frequency with which the partition rebalance check is triggered by the controller.
 
-¦`leader.imbalance.per.broker.percentage`
-a¦The ratio of leader imbalance allowed per broker. The controller would trigger a leader balance if it goes above this value per broker. The value is specified in percentage.
-¦int
-¦10
-¦
-¦high
+`leader.imbalance.per.broker.percentage`::
+*Type:* int +
+*Default:* 10 +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+The ratio of leader imbalance allowed per broker. The controller would trigger a leader balance if it goes above this value per broker. The value is specified in percentage.
 
-¦`listeners`
-a¦Listener List - Comma-separated list of URIs we will listen on and the listener names. If the listener name is not a security protocol, listener.security.protocol.map must also be set.
+`listeners`::
+*Type:* string +
+*Default:* null +
+*Importance:* high +
+*Dynamic update:* per-broker +
++
+Listener List - Comma-separated list of URIs we will listen on and the listener names. If the listener name is not a security protocol, listener.security.protocol.map must also be set.
  Specify hostname as 0.0.0.0 to bind to all interfaces.
  Leave hostname empty to bind to default interface.
  Examples of legal listener lists:
  PLAINTEXT://myhost:9092,SSL://:9091
- CLIENT://0.0.0.0:9092,REPLICATION://localhost:9093
+ CLIENT://0.0.0.0:9092,REPLICATION://localhost:9093.
 
-¦string
-¦null
-¦
-¦high
+`log.dir`::
+*Type:* string +
+*Default:* /tmp/kafka-logs +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+The directory in which the log data is kept (supplemental for log.dirs property).
 
-¦`log.dir`
-a¦The directory in which the log data is kept (supplemental for log.dirs property)
-¦string
-¦/tmp/kafka-logs
-¦
-¦high
+`log.dirs`::
+*Type:* string +
+*Default:* null +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+The directories in which the log data is kept. If not set, the value in log.dir is used.
 
-¦`log.dirs`
-a¦The directories in which the log data is kept. If not set, the value in log.dir is used
-¦string
-¦null
-¦
-¦high
+`log.flush.interval.messages`::
+*Type:* long +
+*Default:* 9223372036854775807 +
+*Valid Values:* [1,...] +
+*Importance:* high +
+*Dynamic update:* cluster-wide +
++
+The number of messages accumulated on a log partition before messages are flushed to disk.
 
-¦`log.flush.interval.messages`
-a¦The number of messages accumulated on a log partition before messages are flushed to disk 
-¦long
-¦9223372036854775807
-¦[1,...]
-¦high
+`log.flush.interval.ms`::
+*Type:* long +
+*Default:* null +
+*Importance:* high +
+*Dynamic update:* cluster-wide +
++
+The maximum time in ms that a message in any topic is kept in memory before flushed to disk. If not set, the value in log.flush.scheduler.interval.ms is used.
 
-¦`log.flush.interval.ms`
-a¦The maximum time in ms that a message in any topic is kept in memory before flushed to disk. If not set, the value in log.flush.scheduler.interval.ms is used
-¦long
-¦null
-¦
-¦high
+`log.flush.offset.checkpoint.interval.ms`::
+*Type:* int +
+*Default:* 60000 +
+*Valid Values:* [0,...] +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+The frequency with which we update the persistent record of the last flush which acts as the log recovery point.
 
-¦`log.flush.offset.checkpoint.interval.ms`
-a¦The frequency with which we update the persistent record of the last flush which acts as the log recovery point
-¦int
-¦60000
-¦[0,...]
-¦high
+`log.flush.scheduler.interval.ms`::
+*Type:* long +
+*Default:* 9223372036854775807 +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+The frequency in ms that the log flusher checks whether any log needs to be flushed to disk.
 
-¦`log.flush.scheduler.interval.ms`
-a¦The frequency in ms that the log flusher checks whether any log needs to be flushed to disk
-¦long
-¦9223372036854775807
-¦
-¦high
+`log.flush.start.offset.checkpoint.interval.ms`::
+*Type:* int +
+*Default:* 60000 +
+*Valid Values:* [0,...] +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+The frequency with which we update the persistent record of log start offset.
 
-¦`log.flush.start.offset.checkpoint.interval.ms`
-a¦The frequency with which we update the persistent record of log start offset
-¦int
-¦60000
-¦[0,...]
-¦high
+`log.retention.bytes`::
+*Type:* long +
+*Default:* -1 +
+*Importance:* high +
+*Dynamic update:* cluster-wide +
++
+The maximum size of the log before deleting it.
 
-¦`log.retention.bytes`
-a¦The maximum size of the log before deleting it
-¦long
-¦-1
-¦
-¦high
+`log.retention.hours`::
+*Type:* int +
+*Default:* 168 +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+The number of hours to keep a log file before deleting it (in hours), tertiary to log.retention.ms property.
 
-¦`log.retention.hours`
-a¦The number of hours to keep a log file before deleting it (in hours), tertiary to log.retention.ms property
-¦int
-¦168
-¦
-¦high
+`log.retention.minutes`::
+*Type:* int +
+*Default:* null +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+The number of minutes to keep a log file before deleting it (in minutes), secondary to log.retention.ms property. If not set, the value in log.retention.hours is used.
 
-¦`log.retention.minutes`
-a¦The number of minutes to keep a log file before deleting it (in minutes), secondary to log.retention.ms property. If not set, the value in log.retention.hours is used
-¦int
-¦null
-¦
-¦high
+`log.retention.ms`::
+*Type:* long +
+*Default:* null +
+*Importance:* high +
+*Dynamic update:* cluster-wide +
++
+The number of milliseconds to keep a log file before deleting it (in milliseconds), If not set, the value in log.retention.minutes is used.
 
-¦`log.retention.ms`
-a¦The number of milliseconds to keep a log file before deleting it (in milliseconds), If not set, the value in log.retention.minutes is used
-¦long
-¦null
-¦
-¦high
+`log.roll.hours`::
+*Type:* int +
+*Default:* 168 +
+*Valid Values:* [1,...] +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+The maximum time before a new log segment is rolled out (in hours), secondary to log.roll.ms property.
 
-¦`log.roll.hours`
-a¦The maximum time before a new log segment is rolled out (in hours), secondary to log.roll.ms property
-¦int
-¦168
-¦[1,...]
-¦high
+`log.roll.jitter.hours`::
+*Type:* int +
+*Default:* 0 +
+*Valid Values:* [0,...] +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+The maximum jitter to subtract from logRollTimeMillis (in hours), secondary to log.roll.jitter.ms property.
 
-¦`log.roll.jitter.hours`
-a¦The maximum jitter to subtract from logRollTimeMillis (in hours), secondary to log.roll.jitter.ms property
-¦int
-¦0
-¦[0,...]
-¦high
+`log.roll.jitter.ms`::
+*Type:* long +
+*Default:* null +
+*Importance:* high +
+*Dynamic update:* cluster-wide +
++
+The maximum jitter to subtract from logRollTimeMillis (in milliseconds). If not set, the value in log.roll.jitter.hours is used.
 
-¦`log.roll.jitter.ms`
-a¦The maximum jitter to subtract from logRollTimeMillis (in milliseconds). If not set, the value in log.roll.jitter.hours is used
-¦long
-¦null
-¦
-¦high
+`log.roll.ms`::
+*Type:* long +
+*Default:* null +
+*Importance:* high +
+*Dynamic update:* cluster-wide +
++
+The maximum time before a new log segment is rolled out (in milliseconds). If not set, the value in log.roll.hours is used.
 
-¦`log.roll.ms`
-a¦The maximum time before a new log segment is rolled out (in milliseconds). If not set, the value in log.roll.hours is used
-¦long
-¦null
-¦
-¦high
+`log.segment.bytes`::
+*Type:* int +
+*Default:* 1073741824 +
+*Valid Values:* [14,...] +
+*Importance:* high +
+*Dynamic update:* cluster-wide +
++
+The maximum size of a single log file.
 
-¦`log.segment.bytes`
-a¦The maximum size of a single log file
-¦int
-¦1073741824
-¦[14,...]
-¦high
+`log.segment.delete.delay.ms`::
+*Type:* long +
+*Default:* 60000 +
+*Valid Values:* [0,...] +
+*Importance:* high +
+*Dynamic update:* cluster-wide +
++
+The amount of time to wait before deleting a file from the filesystem.
 
-¦`log.segment.delete.delay.ms`
-a¦The amount of time to wait before deleting a file from the filesystem
-¦long
-¦60000
-¦[0,...]
-¦high
+`message.max.bytes`::
+*Type:* int +
+*Default:* 1000012 +
+*Valid Values:* [0,...] +
+*Importance:* high +
+*Dynamic update:* cluster-wide +
++
 
-¦`message.max.bytes`
-a¦
++
 The largest record batch size allowed by Kafka. If this is increased and there are consumers older than 0.10.2, the consumers' fetch size must also be increased so that the they can fetch record batches this large.
-
++
 In the latest message format version, records are always grouped into batches for efficiency. In previous message format versions, uncompressed records are not grouped into batches and this limit only applies to a single record in that case.
-
++
 This can be set per topic with the topic level `max.message.bytes` config.
 
-¦int
-¦1000012
-¦[0,...]
-¦high
 
-¦`min.insync.replicas`
-a¦When a producer sets acks to "all" (or "-1"), min.insync.replicas specifies the minimum number of replicas that must acknowledge a write for the write to be considered successful. If this minimum cannot be met, then the producer will raise an exception (either NotEnoughReplicas or NotEnoughReplicasAfterAppend).
+`min.insync.replicas`::
+*Type:* int +
+*Default:* 1 +
+*Valid Values:* [1,...] +
+*Importance:* high +
+*Dynamic update:* cluster-wide +
++
+When a producer sets acks to "all" (or "-1"), min.insync.replicas specifies the minimum number of replicas that must acknowledge a write for the write to be considered successful. If this minimum cannot be met, then the producer will raise an exception (either NotEnoughReplicas or NotEnoughReplicasAfterAppend).
 When used together, min.insync.replicas and acks allow you to enforce greater durability guarantees. A typical scenario would be to create a topic with a replication factor of 3, set min.insync.replicas to 2, and produce with acks of "all". This will ensure that the producer raises an exception if a majority of replicas do not receive a write.
-¦int
-¦1
-¦[1,...]
-¦high
 
-¦`num.io.threads`
-a¦The number of threads that the server uses for processing requests, which may include disk I/O
-¦int
-¦8
-¦[1,...]
-¦high
+`num.io.threads`::
+*Type:* int +
+*Default:* 8 +
+*Valid Values:* [1,...] +
+*Importance:* high +
+*Dynamic update:* cluster-wide +
++
+The number of threads that the server uses for processing requests, which may include disk I/O.
 
-¦`num.network.threads`
-a¦The number of threads that the server uses for receiving requests from the network and sending responses to the network
-¦int
-¦3
-¦[1,...]
-¦high
+`num.network.threads`::
+*Type:* int +
+*Default:* 3 +
+*Valid Values:* [1,...] +
+*Importance:* high +
+*Dynamic update:* cluster-wide +
++
+The number of threads that the server uses for receiving requests from the network and sending responses to the network.
 
-¦`num.recovery.threads.per.data.dir`
-a¦The number of threads per data directory to be used for log recovery at startup and flushing at shutdown
-¦int
-¦1
-¦[1,...]
-¦high
+`num.recovery.threads.per.data.dir`::
+*Type:* int +
+*Default:* 1 +
+*Valid Values:* [1,...] +
+*Importance:* high +
+*Dynamic update:* cluster-wide +
++
+The number of threads per data directory to be used for log recovery at startup and flushing at shutdown.
 
-¦`num.replica.alter.log.dirs.threads`
-a¦The number of threads that can move replicas between log directories, which may include disk I/O
-¦int
-¦null
-¦
-¦high
+`num.replica.alter.log.dirs.threads`::
+*Type:* int +
+*Default:* null +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+The number of threads that can move replicas between log directories, which may include disk I/O.
 
-¦`num.replica.fetchers`
-a¦Number of fetcher threads used to replicate messages from a source broker. Increasing this value can increase the degree of I/O parallelism in the follower broker.
-¦int
-¦1
-¦
-¦high
+`num.replica.fetchers`::
+*Type:* int +
+*Default:* 1 +
+*Importance:* high +
+*Dynamic update:* cluster-wide +
++
+Number of fetcher threads used to replicate messages from a source broker. Increasing this value can increase the degree of I/O parallelism in the follower broker.
 
-¦`offset.metadata.max.bytes`
-a¦The maximum size for a metadata entry associated with an offset commit
-¦int
-¦4096
-¦
-¦high
+`offset.metadata.max.bytes`::
+*Type:* int +
+*Default:* 4096 +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+The maximum size for a metadata entry associated with an offset commit.
 
-¦`offsets.commit.required.acks`
-a¦The required acks before the commit can be accepted. In general, the default (-1) should not be overridden
-¦short
-¦-1
-¦
-¦high
+`offsets.commit.required.acks`::
+*Type:* short +
+*Default:* -1 +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+The required acks before the commit can be accepted. In general, the default (-1) should not be overridden.
 
-¦`offsets.commit.timeout.ms`
-a¦Offset commit will be delayed until all replicas for the offsets topic receive the commit or this timeout is reached. This is similar to the producer request timeout.
-¦int
-¦5000
-¦[1,...]
-¦high
+`offsets.commit.timeout.ms`::
+*Type:* int +
+*Default:* 5000 +
+*Valid Values:* [1,...] +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+Offset commit will be delayed until all replicas for the offsets topic receive the commit or this timeout is reached. This is similar to the producer request timeout.
 
-¦`offsets.load.buffer.size`
-a¦Batch size for reading from the offsets segments when loading offsets into the cache.
-¦int
-¦5242880
-¦[1,...]
-¦high
+`offsets.load.buffer.size`::
+*Type:* int +
+*Default:* 5242880 +
+*Valid Values:* [1,...] +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+Batch size for reading from the offsets segments when loading offsets into the cache.
 
-¦`offsets.retention.check.interval.ms`
-a¦Frequency at which to check for stale offsets
-¦long
-¦600000
-¦[1,...]
-¦high
+`offsets.retention.check.interval.ms`::
+*Type:* long +
+*Default:* 600000 +
+*Valid Values:* [1,...] +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+Frequency at which to check for stale offsets.
 
-¦`offsets.retention.minutes`
-a¦Offsets older than this retention period will be discarded
-¦int
-¦10080
-¦[1,...]
-¦high
+`offsets.retention.minutes`::
+*Type:* int +
+*Default:* 10080 +
+*Valid Values:* [1,...] +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+Offsets older than this retention period will be discarded.
 
-¦`offsets.topic.compression.codec`
-a¦Compression codec for the offsets topic - compression may be used to achieve "atomic" commits
-¦int
-¦0
-¦
-¦high
+`offsets.topic.compression.codec`::
+*Type:* int +
+*Default:* 0 +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+Compression codec for the offsets topic - compression may be used to achieve "atomic" commits.
 
-¦`offsets.topic.num.partitions`
-a¦The number of partitions for the offset commit topic (should not change after deployment)
-¦int
-¦50
-¦[1,...]
-¦high
+`offsets.topic.num.partitions`::
+*Type:* int +
+*Default:* 50 +
+*Valid Values:* [1,...] +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+The number of partitions for the offset commit topic (should not change after deployment).
 
-¦`offsets.topic.replication.factor`
-a¦The replication factor for the offsets topic (set higher to ensure availability). Internal topic creation will fail until the cluster size meets this replication factor requirement.
-¦short
-¦3
-¦[1,...]
-¦high
+`offsets.topic.replication.factor`::
+*Type:* short +
+*Default:* 3 +
+*Valid Values:* [1,...] +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+The replication factor for the offsets topic (set higher to ensure availability). Internal topic creation will fail until the cluster size meets this replication factor requirement.
 
-¦`offsets.topic.segment.bytes`
-a¦The offsets topic segment bytes should be kept relatively small in order to facilitate faster log compaction and cache loads
-¦int
-¦104857600
-¦[1,...]
-¦high
+`offsets.topic.segment.bytes`::
+*Type:* int +
+*Default:* 104857600 +
+*Valid Values:* [1,...] +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+The offsets topic segment bytes should be kept relatively small in order to facilitate faster log compaction and cache loads.
 
-¦`port`
-a¦DEPRECATED: only used when `listeners` is not set. Use `listeners` instead. 
-the port to listen and accept connections on
-¦int
-¦9092
-¦
-¦high
+`port`::
+*Type:* int +
+*Default:* 9092 +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+DEPRECATED: only used when `listeners` is not set. Use `listeners` instead. 
+the port to listen and accept connections on.
 
-¦`queued.max.requests`
-a¦The number of queued requests allowed before blocking the network threads
-¦int
-¦500
-¦[1,...]
-¦high
+`queued.max.requests`::
+*Type:* int +
+*Default:* 500 +
+*Valid Values:* [1,...] +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+The number of queued requests allowed before blocking the network threads.
 
-¦`quota.consumer.default`
-a¦DEPRECATED: Used only when dynamic default quotas are not configured for <user, <client-id> or <user, client-id> in Zookeeper. Any consumer distinguished by clientId/consumer group will get throttled if it fetches more bytes than this value per-second
-¦long
-¦9223372036854775807
-¦[1,...]
-¦high
+`quota.consumer.default`::
+*Type:* long +
+*Default:* 9223372036854775807 +
+*Valid Values:* [1,...] +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+DEPRECATED: Used only when dynamic default quotas are not configured for <user, <client-id> or <user, client-id> in Zookeeper. Any consumer distinguished by clientId/consumer group will get throttled if it fetches more bytes than this value per-second.
 
-¦`quota.producer.default`
-a¦DEPRECATED: Used only when dynamic default quotas are not configured for <user>, <client-id> or <user, client-id> in Zookeeper. Any producer distinguished by clientId will get throttled if it produces more bytes than this value per-second
-¦long
-¦9223372036854775807
-¦[1,...]
-¦high
+`quota.producer.default`::
+*Type:* long +
+*Default:* 9223372036854775807 +
+*Valid Values:* [1,...] +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+DEPRECATED: Used only when dynamic default quotas are not configured for <user>, <client-id> or <user, client-id> in Zookeeper. Any producer distinguished by clientId will get throttled if it produces more bytes than this value per-second.
 
-¦`replica.fetch.min.bytes`
-a¦Minimum bytes expected for each fetch response. If not enough bytes, wait up to replicaMaxWaitTimeMs
-¦int
-¦1
-¦
-¦high
+`replica.fetch.min.bytes`::
+*Type:* int +
+*Default:* 1 +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+Minimum bytes expected for each fetch response. If not enough bytes, wait up to replicaMaxWaitTimeMs.
 
-¦`replica.fetch.wait.max.ms`
-a¦max wait time for each fetcher request issued by follower replicas. This value should always be less than the replica.lag.time.max.ms at all times to prevent frequent shrinking of ISR for low throughput topics
-¦int
-¦500
-¦
-¦high
+`replica.fetch.wait.max.ms`::
+*Type:* int +
+*Default:* 500 +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+max wait time for each fetcher request issued by follower replicas. This value should always be less than the replica.lag.time.max.ms at all times to prevent frequent shrinking of ISR for low throughput topics.
 
-¦`replica.high.watermark.checkpoint.interval.ms`
-a¦The frequency with which the high watermark is saved out to disk
-¦long
-¦5000
-¦
-¦high
+`replica.high.watermark.checkpoint.interval.ms`::
+*Type:* long +
+*Default:* 5000 +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+The frequency with which the high watermark is saved out to disk.
 
-¦`replica.lag.time.max.ms`
-a¦If a follower hasn't sent any fetch requests or hasn't consumed up to the leaders log end offset for at least this time, the leader will remove the follower from isr
-¦long
-¦10000
-¦
-¦high
+`replica.lag.time.max.ms`::
+*Type:* long +
+*Default:* 10000 +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+If a follower hasn't sent any fetch requests or hasn't consumed up to the leaders log end offset for at least this time, the leader will remove the follower from isr.
 
-¦`replica.socket.receive.buffer.bytes`
-a¦The socket receive buffer for network requests
-¦int
-¦65536
-¦
-¦high
+`replica.socket.receive.buffer.bytes`::
+*Type:* int +
+*Default:* 65536 +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+The socket receive buffer for network requests.
 
-¦`replica.socket.timeout.ms`
-a¦The socket timeout for network requests. Its value should be at least replica.fetch.wait.max.ms
-¦int
-¦30000
-¦
-¦high
+`replica.socket.timeout.ms`::
+*Type:* int +
+*Default:* 30000 +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+The socket timeout for network requests. Its value should be at least replica.fetch.wait.max.ms.
 
-¦`request.timeout.ms`
-a¦The configuration controls the maximum amount of time the client will wait for the response of a request. If the response is not received before the timeout elapses the client will resend the request if necessary or fail the request if retries are exhausted.
-¦int
-¦30000
-¦
-¦high
+`request.timeout.ms`::
+*Type:* int +
+*Default:* 30000 +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+The configuration controls the maximum amount of time the client will wait for the response of a request. If the response is not received before the timeout elapses the client will resend the request if necessary or fail the request if retries are exhausted.
 
-¦`socket.receive.buffer.bytes`
-a¦The SO_RCVBUF buffer of the socket sever sockets. If the value is -1, the OS default will be used.
-¦int
-¦102400
-¦
-¦high
+`socket.receive.buffer.bytes`::
+*Type:* int +
+*Default:* 102400 +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+The SO_RCVBUF buffer of the socket sever sockets. If the value is -1, the OS default will be used.
 
-¦`socket.request.max.bytes`
-a¦The maximum number of bytes in a socket request
-¦int
-¦104857600
-¦[1,...]
-¦high
+`socket.request.max.bytes`::
+*Type:* int +
+*Default:* 104857600 +
+*Valid Values:* [1,...] +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+The maximum number of bytes in a socket request.
 
-¦`socket.send.buffer.bytes`
-a¦The SO_SNDBUF buffer of the socket sever sockets. If the value is -1, the OS default will be used.
-¦int
-¦102400
-¦
-¦high
+`socket.send.buffer.bytes`::
+*Type:* int +
+*Default:* 102400 +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+The SO_SNDBUF buffer of the socket sever sockets. If the value is -1, the OS default will be used.
 
-¦`transaction.max.timeout.ms`
-a¦The maximum allowed timeout for transactions. If a client’s requested transaction time exceed this, then the broker will return an error in InitProducerIdRequest. This prevents a client from too large of a timeout, which can stall consumers reading from topics included in the transaction.
-¦int
-¦900000
-¦[1,...]
-¦high
+`transaction.max.timeout.ms`::
+*Type:* int +
+*Default:* 900000 +
+*Valid Values:* [1,...] +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+The maximum allowed timeout for transactions. If a client’s requested transaction time exceed this, then the broker will return an error in InitProducerIdRequest. This prevents a client from too large of a timeout, which can stall consumers reading from topics included in the transaction.
 
-¦`transaction.state.log.load.buffer.size`
-a¦Batch size for reading from the transaction log segments when loading producer ids and transactions into the cache.
-¦int
-¦5242880
-¦[1,...]
-¦high
+`transaction.state.log.load.buffer.size`::
+*Type:* int +
+*Default:* 5242880 +
+*Valid Values:* [1,...] +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+Batch size for reading from the transaction log segments when loading producer ids and transactions into the cache.
 
-¦`transaction.state.log.min.isr`
-a¦Overridden min.insync.replicas config for the transaction topic.
-¦int
-¦2
-¦[1,...]
-¦high
+`transaction.state.log.min.isr`::
+*Type:* int +
+*Default:* 2 +
+*Valid Values:* [1,...] +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+Overridden min.insync.replicas config for the transaction topic.
 
-¦`transaction.state.log.num.partitions`
-a¦The number of partitions for the transaction topic (should not change after deployment).
-¦int
-¦50
-¦[1,...]
-¦high
+`transaction.state.log.num.partitions`::
+*Type:* int +
+*Default:* 50 +
+*Valid Values:* [1,...] +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+The number of partitions for the transaction topic (should not change after deployment).
 
-¦`transaction.state.log.replication.factor`
-a¦The replication factor for the transaction topic (set higher to ensure availability). Internal topic creation will fail until the cluster size meets this replication factor requirement.
-¦short
-¦3
-¦[1,...]
-¦high
+`transaction.state.log.replication.factor`::
+*Type:* short +
+*Default:* 3 +
+*Valid Values:* [1,...] +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+The replication factor for the transaction topic (set higher to ensure availability). Internal topic creation will fail until the cluster size meets this replication factor requirement.
 
-¦`transaction.state.log.segment.bytes`
-a¦The transaction topic segment bytes should be kept relatively small in order to facilitate faster log compaction and cache loads
-¦int
-¦104857600
-¦[1,...]
-¦high
+`transaction.state.log.segment.bytes`::
+*Type:* int +
+*Default:* 104857600 +
+*Valid Values:* [1,...] +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+The transaction topic segment bytes should be kept relatively small in order to facilitate faster log compaction and cache loads.
 
-¦`transactional.id.expiration.ms`
-a¦The maximum amount of time in ms that the transaction coordinator will wait before proactively expire a producer's transactional id without receiving any transaction status updates from it.
-¦int
-¦604800000
-¦[1,...]
-¦high
+`transactional.id.expiration.ms`::
+*Type:* int +
+*Default:* 604800000 +
+*Valid Values:* [1,...] +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+The maximum amount of time in ms that the transaction coordinator will wait before proactively expire a producer's transactional id without receiving any transaction status updates from it.
 
-¦`unclean.leader.election.enable`
-a¦Indicates whether to enable replicas not in the ISR set to be elected as leader as a last resort, even though doing so may result in data loss
-¦boolean
-¦false
-¦
-¦high
+`unclean.leader.election.enable`::
+*Type:* boolean +
+*Default:* false +
+*Importance:* high +
+*Dynamic update:* cluster-wide +
++
+Indicates whether to enable replicas not in the ISR set to be elected as leader as a last resort, even though doing so may result in data loss.
 
-¦`zookeeper.connection.timeout.ms`
-a¦The max time that the client waits to establish a connection to zookeeper. If not set, the value in zookeeper.session.timeout.ms is used
-¦int
-¦null
-¦
-¦high
+`zookeeper.connection.timeout.ms`::
+*Type:* int +
+*Default:* null +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+The max time that the client waits to establish a connection to zookeeper. If not set, the value in zookeeper.session.timeout.ms is used.
 
-¦`zookeeper.max.in.flight.requests`
-a¦The maximum number of unacknowledged requests the client will send to Zookeeper before blocking.
-¦int
-¦10
-¦[1,...]
-¦high
+`zookeeper.max.in.flight.requests`::
+*Type:* int +
+*Default:* 10 +
+*Valid Values:* [1,...] +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+The maximum number of unacknowledged requests the client will send to Zookeeper before blocking.
 
-¦`zookeeper.session.timeout.ms`
-a¦Zookeeper session timeout
-¦int
-¦6000
-¦
-¦high
+`zookeeper.session.timeout.ms`::
+*Type:* int +
+*Default:* 6000 +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+Zookeeper session timeout.
 
-¦`zookeeper.set.acl`
-a¦Set client to use secure ACLs
-¦boolean
-¦false
-¦
-¦high
+`zookeeper.set.acl`::
+*Type:* boolean +
+*Default:* false +
+*Importance:* high +
+*Dynamic update:* read-only +
++
+Set client to use secure ACLs.
 
-¦`broker.id.generation.enable`
-a¦Enable automatic broker id generation on the server. When enabled the value configured for reserved.broker.max.id should be reviewed.
-¦boolean
-¦true
-¦
-¦medium
+`broker.id.generation.enable`::
+*Type:* boolean +
+*Default:* true +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+Enable automatic broker id generation on the server. When enabled the value configured for reserved.broker.max.id should be reviewed.
 
-¦`broker.rack`
-a¦Rack of the broker. This will be used in rack aware replication assignment for fault tolerance. Examples: `RACK1`, `us-east-1d`
-¦string
-¦null
-¦
-¦medium
+`broker.rack`::
+*Type:* string +
+*Default:* null +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+Rack of the broker. This will be used in rack aware replication assignment for fault tolerance. Examples: `RACK1`, `us-east-1d`.
 
-¦`connections.max.idle.ms`
-a¦Idle connections timeout: the server socket processor threads close the connections that idle more than this
-¦long
-¦600000
-¦
-¦medium
+`connections.max.idle.ms`::
+*Type:* long +
+*Default:* 600000 +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+Idle connections timeout: the server socket processor threads close the connections that idle more than this.
 
-¦`controlled.shutdown.enable`
-a¦Enable controlled shutdown of the server
-¦boolean
-¦true
-¦
-¦medium
+`controlled.shutdown.enable`::
+*Type:* boolean +
+*Default:* true +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+Enable controlled shutdown of the server.
 
-¦`controlled.shutdown.max.retries`
-a¦Controlled shutdown can fail for multiple reasons. This determines the number of retries when such failure happens
-¦int
-¦3
-¦
-¦medium
+`controlled.shutdown.max.retries`::
+*Type:* int +
+*Default:* 3 +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+Controlled shutdown can fail for multiple reasons. This determines the number of retries when such failure happens.
 
-¦`controlled.shutdown.retry.backoff.ms`
-a¦Before each retry, the system needs time to recover from the state that caused the previous failure (Controller fail over, replica lag etc). This config determines the amount of time to wait before retrying.
-¦long
-¦5000
-¦
-¦medium
+`controlled.shutdown.retry.backoff.ms`::
+*Type:* long +
+*Default:* 5000 +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+Before each retry, the system needs time to recover from the state that caused the previous failure (Controller fail over, replica lag etc). This config determines the amount of time to wait before retrying.
 
-¦`controller.socket.timeout.ms`
-a¦The socket timeout for controller-to-broker channels
-¦int
-¦30000
-¦
-¦medium
+`controller.socket.timeout.ms`::
+*Type:* int +
+*Default:* 30000 +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+The socket timeout for controller-to-broker channels.
 
-¦`default.replication.factor`
-a¦default replication factors for automatically created topics
-¦int
-¦1
-¦
-¦medium
+`default.replication.factor`::
+*Type:* int +
+*Default:* 1 +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+default replication factors for automatically created topics.
 
-¦`delegation.token.expiry.time.ms`
-a¦The token validity time in seconds before the token needs to be renewed. Default value 1 day.
-¦long
-¦86400000
-¦[1,...]
-¦medium
+`delegation.token.expiry.time.ms`::
+*Type:* long +
+*Default:* 86400000 +
+*Valid Values:* [1,...] +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+The token validity time in seconds before the token needs to be renewed. Default value 1 day.
 
-¦`delegation.token.master.key`
-a¦Master/secret key to generate and verify delegation tokens. Same key must be configured across all the brokers.  If the key is not set or set to empty string, brokers will disable the delegation token support.
-¦password
-¦null
-¦
-¦medium
+`delegation.token.master.key`::
+*Type:* password +
+*Default:* null +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+Master/secret key to generate and verify delegation tokens. Same key must be configured across all the brokers.  If the key is not set or set to empty string, brokers will disable the delegation token support.
 
-¦`delegation.token.max.lifetime.ms`
-a¦The token has a maximum lifetime beyond which it cannot be renewed anymore. Default value 7 days.
-¦long
-¦604800000
-¦[1,...]
-¦medium
+`delegation.token.max.lifetime.ms`::
+*Type:* long +
+*Default:* 604800000 +
+*Valid Values:* [1,...] +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+The token has a maximum lifetime beyond which it cannot be renewed anymore. Default value 7 days.
 
-¦`delete.records.purgatory.purge.interval.requests`
-a¦The purge interval (in number of requests) of the delete records request purgatory
-¦int
-¦1
-¦
-¦medium
+`delete.records.purgatory.purge.interval.requests`::
+*Type:* int +
+*Default:* 1 +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+The purge interval (in number of requests) of the delete records request purgatory.
 
-¦`fetch.purgatory.purge.interval.requests`
-a¦The purge interval (in number of requests) of the fetch request purgatory
-¦int
-¦1000
-¦
-¦medium
+`fetch.purgatory.purge.interval.requests`::
+*Type:* int +
+*Default:* 1000 +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+The purge interval (in number of requests) of the fetch request purgatory.
 
-¦`group.initial.rebalance.delay.ms`
-a¦The amount of time the group coordinator will wait for more consumers to join a new group before performing the first rebalance. A longer delay means potentially fewer rebalances, but increases the time until processing begins.
-¦int
-¦3000
-¦
-¦medium
+`group.initial.rebalance.delay.ms`::
+*Type:* int +
+*Default:* 3000 +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+The amount of time the group coordinator will wait for more consumers to join a new group before performing the first rebalance. A longer delay means potentially fewer rebalances, but increases the time until processing begins.
 
-¦`group.max.session.timeout.ms`
-a¦The maximum allowed session timeout for registered consumers. Longer timeouts give consumers more time to process messages in between heartbeats at the cost of a longer time to detect failures.
-¦int
-¦300000
-¦
-¦medium
+`group.max.session.timeout.ms`::
+*Type:* int +
+*Default:* 300000 +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+The maximum allowed session timeout for registered consumers. Longer timeouts give consumers more time to process messages in between heartbeats at the cost of a longer time to detect failures.
 
-¦`group.min.session.timeout.ms`
-a¦The minimum allowed session timeout for registered consumers. Shorter timeouts result in quicker failure detection at the cost of more frequent consumer heartbeating, which can overwhelm broker resources.
-¦int
-¦6000
-¦
-¦medium
+`group.min.session.timeout.ms`::
+*Type:* int +
+*Default:* 6000 +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+The minimum allowed session timeout for registered consumers. Shorter timeouts result in quicker failure detection at the cost of more frequent consumer heartbeating, which can overwhelm broker resources.
 
-¦`inter.broker.listener.name`
-a¦Name of listener used for communication between brokers. If this is unset, the listener name is defined by security.inter.broker.protocol. It is an error to set this and security.inter.broker.protocol properties at the same time.
-¦string
-¦null
-¦
-¦medium
+`inter.broker.listener.name`::
+*Type:* string +
+*Default:* null +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+Name of listener used for communication between brokers. If this is unset, the listener name is defined by security.inter.broker.protocol. It is an error to set this and security.inter.broker.protocol properties at the same time.
 
-¦`inter.broker.protocol.version`
-a¦Specify which version of the inter-broker protocol will be used.
+`inter.broker.protocol.version`::
+*Type:* string +
+*Default:* 2.0-IV1 +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+Specify which version of the inter-broker protocol will be used.
  This is typically bumped after all brokers were upgraded to a new version.
  Example of some valid values are: 0.8.0, 0.8.1, 0.8.1.1, 0.8.2, 0.8.2.0, 0.8.2.1, 0.9.0.0, 0.9.0.1 Check ApiVersion for the full list.
-¦string
-¦2.0-IV1
-¦
-¦medium
 
-¦`log.cleaner.backoff.ms`
-a¦The amount of time to sleep when there are no logs to clean
-¦long
-¦15000
-¦[0,...]
-¦medium
+`log.cleaner.backoff.ms`::
+*Type:* long +
+*Default:* 15000 +
+*Valid Values:* [0,...] +
+*Importance:* medium +
+*Dynamic update:* cluster-wide +
++
+The amount of time to sleep when there are no logs to clean.
 
-¦`log.cleaner.dedupe.buffer.size`
-a¦The total memory used for log deduplication across all cleaner threads
-¦long
-¦134217728
-¦
-¦medium
+`log.cleaner.dedupe.buffer.size`::
+*Type:* long +
+*Default:* 134217728 +
+*Importance:* medium +
+*Dynamic update:* cluster-wide +
++
+The total memory used for log deduplication across all cleaner threads.
 
-¦`log.cleaner.delete.retention.ms`
-a¦How long are delete records retained?
-¦long
-¦86400000
-¦
-¦medium
+`log.cleaner.delete.retention.ms`::
+*Type:* long +
+*Default:* 86400000 +
+*Importance:* medium +
+*Dynamic update:* cluster-wide +
++
+How long are delete records retained?
 
-¦`log.cleaner.enable`
-a¦Enable the log cleaner process to run on the server. Should be enabled if using any topics with a cleanup.policy=compact including the internal offsets topic. If disabled those topics will not be compacted and continually grow in size.
-¦boolean
-¦true
-¦
-¦medium
+`log.cleaner.enable`::
+*Type:* boolean +
+*Default:* true +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+Enable the log cleaner process to run on the server. Should be enabled if using any topics with a cleanup.policy=compact including the internal offsets topic. If disabled those topics will not be compacted and continually grow in size.
 
-¦`log.cleaner.io.buffer.load.factor`
-a¦Log cleaner dedupe buffer load factor. The percentage full the dedupe buffer can become. A higher value will allow more log to be cleaned at once but will lead to more hash collisions
-¦double
-¦0.9
-¦
-¦medium
+`log.cleaner.io.buffer.load.factor`::
+*Type:* double +
+*Default:* 0.9 +
+*Importance:* medium +
+*Dynamic update:* cluster-wide +
++
+Log cleaner dedupe buffer load factor. The percentage full the dedupe buffer can become. A higher value will allow more log to be cleaned at once but will lead to more hash collisions.
 
-¦`log.cleaner.io.buffer.size`
-a¦The total memory used for log cleaner I/O buffers across all cleaner threads
-¦int
-¦524288
-¦[0,...]
-¦medium
+`log.cleaner.io.buffer.size`::
+*Type:* int +
+*Default:* 524288 +
+*Valid Values:* [0,...] +
+*Importance:* medium +
+*Dynamic update:* cluster-wide +
++
+The total memory used for log cleaner I/O buffers across all cleaner threads.
 
-¦`log.cleaner.io.max.bytes.per.second`
-a¦The log cleaner will be throttled so that the sum of its read and write i/o will be less than this value on average
-¦double
-¦1.7976931348623157E308
-¦
-¦medium
+`log.cleaner.io.max.bytes.per.second`::
+*Type:* double +
+*Default:* 1.7976931348623157E308 +
+*Importance:* medium +
+*Dynamic update:* cluster-wide +
++
+The log cleaner will be throttled so that the sum of its read and write i/o will be less than this value on average.
 
-¦`log.cleaner.min.cleanable.ratio`
-a¦The minimum ratio of dirty log to total log for a log to eligible for cleaning
-¦double
-¦0.5
-¦
-¦medium
+`log.cleaner.min.cleanable.ratio`::
+*Type:* double +
+*Default:* 0.5 +
+*Importance:* medium +
+*Dynamic update:* cluster-wide +
++
+The minimum ratio of dirty log to total log for a log to eligible for cleaning.
 
-¦`log.cleaner.min.compaction.lag.ms`
-a¦The minimum time a message will remain uncompacted in the log. Only applicable for logs that are being compacted.
-¦long
-¦0
-¦
-¦medium
+`log.cleaner.min.compaction.lag.ms`::
+*Type:* long +
+*Default:* 0 +
+*Importance:* medium +
+*Dynamic update:* cluster-wide +
++
+The minimum time a message will remain uncompacted in the log. Only applicable for logs that are being compacted.
 
-¦`log.cleaner.threads`
-a¦The number of background threads to use for log cleaning
-¦int
-¦1
-¦[0,...]
-¦medium
+`log.cleaner.threads`::
+*Type:* int +
+*Default:* 1 +
+*Valid Values:* [0,...] +
+*Importance:* medium +
+*Dynamic update:* cluster-wide +
++
+The number of background threads to use for log cleaning.
 
-¦`log.cleanup.policy`
-a¦The default cleanup policy for segments beyond the retention window. A comma separated list of valid policies. Valid policies are: "delete" and "compact"
-¦list
-¦delete
-¦[compact, delete]
-¦medium
+`log.cleanup.policy`::
+*Type:* list +
+*Default:* delete +
+*Valid Values:* [compact, delete] +
+*Importance:* medium +
+*Dynamic update:* cluster-wide +
++
+The default cleanup policy for segments beyond the retention window. A comma separated list of valid policies. Valid policies are: "delete" and "compact".
 
-¦`log.index.interval.bytes`
-a¦The interval with which we add an entry to the offset index
-¦int
-¦4096
-¦[0,...]
-¦medium
+`log.index.interval.bytes`::
+*Type:* int +
+*Default:* 4096 +
+*Valid Values:* [0,...] +
+*Importance:* medium +
+*Dynamic update:* cluster-wide +
++
+The interval with which we add an entry to the offset index.
 
-¦`log.index.size.max.bytes`
-a¦The maximum size in bytes of the offset index
-¦int
-¦10485760
-¦[4,...]
-¦medium
+`log.index.size.max.bytes`::
+*Type:* int +
+*Default:* 10485760 +
+*Valid Values:* [4,...] +
+*Importance:* medium +
+*Dynamic update:* cluster-wide +
++
+The maximum size in bytes of the offset index.
 
-¦`log.message.format.version`
-a¦Specify the message format version the broker will use to append messages to the logs. The value should be a valid ApiVersion. Some examples are: 0.8.2, 0.9.0.0, 0.10.0, check ApiVersion for more details. By setting a particular message format version, the user is certifying that all the existing messages on disk are smaller or equal than the specified version. Setting this value incorrectly will cause consumers with older versions to break as they will receive messages with a format that they don't understand.
-¦string
-¦2.0-IV1
-¦
-¦medium
+`log.message.format.version`::
+*Type:* string +
+*Default:* 2.0-IV1 +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+Specify the message format version the broker will use to append messages to the logs. The value should be a valid ApiVersion. Some examples are: 0.8.2, 0.9.0.0, 0.10.0, check ApiVersion for more details. By setting a particular message format version, the user is certifying that all the existing messages on disk are smaller or equal than the specified version. Setting this value incorrectly will cause consumers with older versions to break as they will receive messages with a format that they don't understand.
 
-¦`log.message.timestamp.difference.max.ms`
-a¦The maximum difference allowed between the timestamp when a broker receives a message and the timestamp specified in the message. If log.message.timestamp.type=CreateTime, a message will be rejected if the difference in timestamp exceeds this threshold. This configuration is ignored if log.message.timestamp.type=LogAppendTime.The maximum timestamp difference allowed should be no greater than log.retention.ms to avoid unnecessarily frequent log rolling.
-¦long
-¦9223372036854775807
-¦
-¦medium
+`log.message.timestamp.difference.max.ms`::
+*Type:* long +
+*Default:* 9223372036854775807 +
+*Importance:* medium +
+*Dynamic update:* cluster-wide +
++
+The maximum difference allowed between the timestamp when a broker receives a message and the timestamp specified in the message. If log.message.timestamp.type=CreateTime, a message will be rejected if the difference in timestamp exceeds this threshold. This configuration is ignored if log.message.timestamp.type=LogAppendTime.The maximum timestamp difference allowed should be no greater than log.retention.ms to avoid unnecessarily frequent log rolling.
 
-¦`log.message.timestamp.type`
-a¦Define whether the timestamp in the message is message create time or log append time. The value should be either `CreateTime` or `LogAppendTime`
-¦string
-¦CreateTime
-¦[CreateTime, LogAppendTime]
-¦medium
+`log.message.timestamp.type`::
+*Type:* string +
+*Default:* CreateTime +
+*Valid Values:* [CreateTime, LogAppendTime] +
+*Importance:* medium +
+*Dynamic update:* cluster-wide +
++
+Define whether the timestamp in the message is message create time or log append time. The value should be either `CreateTime` or `LogAppendTime`.
 
-¦`log.preallocate`
-a¦Should pre allocate file when create new segment? If you are using Kafka on Windows, you probably need to set it to true.
-¦boolean
-¦false
-¦
-¦medium
+`log.preallocate`::
+*Type:* boolean +
+*Default:* false +
+*Importance:* medium +
+*Dynamic update:* cluster-wide +
++
+Should pre allocate file when create new segment? If you are using Kafka on Windows, you probably need to set it to true.
 
-¦`log.retention.check.interval.ms`
-a¦The frequency in milliseconds that the log cleaner checks whether any log is eligible for deletion
-¦long
-¦300000
-¦[1,...]
-¦medium
+`log.retention.check.interval.ms`::
+*Type:* long +
+*Default:* 300000 +
+*Valid Values:* [1,...] +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+The frequency in milliseconds that the log cleaner checks whether any log is eligible for deletion.
 
-¦`max.connections.per.ip`
-a¦The maximum number of connections we allow from each ip address. This can be set to 0 if there are overrides configured using max.connections.per.ip.overrides property
-¦int
-¦2147483647
-¦[0,...]
-¦medium
+`max.connections.per.ip`::
+*Type:* int +
+*Default:* 2147483647 +
+*Valid Values:* [0,...] +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+The maximum number of connections we allow from each ip address. This can be set to 0 if there are overrides configured using max.connections.per.ip.overrides property.
 
-¦`max.connections.per.ip.overrides`
-a¦A comma-separated list of per-ip or hostname overrides to the default maximum number of connections. An example value is "hostName:100,127.0.0.1:200"
-¦string
-¦""
-¦
-¦medium
+`max.connections.per.ip.overrides`::
+*Type:* string +
+*Default:* "" +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+A comma-separated list of per-ip or hostname overrides to the default maximum number of connections. An example value is "hostName:100,127.0.0.1:200".
 
-¦`max.incremental.fetch.session.cache.slots`
-a¦The maximum number of incremental fetch sessions that we will maintain.
-¦int
-¦1000
-¦[0,...]
-¦medium
+`max.incremental.fetch.session.cache.slots`::
+*Type:* int +
+*Default:* 1000 +
+*Valid Values:* [0,...] +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+The maximum number of incremental fetch sessions that we will maintain.
 
-¦`num.partitions`
-a¦The default number of log partitions per topic
-¦int
-¦1
-¦[1,...]
-¦medium
+`num.partitions`::
+*Type:* int +
+*Default:* 1 +
+*Valid Values:* [1,...] +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+The default number of log partitions per topic.
 
-¦`password.encoder.old.secret`
-a¦The old secret that was used for encoding dynamically configured passwords. This is required only when the secret is updated. If specified, all dynamically encoded passwords are decoded using this old secret and re-encoded using password.encoder.secret when broker starts up.
-¦password
-¦null
-¦
-¦medium
+`password.encoder.old.secret`::
+*Type:* password +
+*Default:* null +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+The old secret that was used for encoding dynamically configured passwords. This is required only when the secret is updated. If specified, all dynamically encoded passwords are decoded using this old secret and re-encoded using password.encoder.secret when broker starts up.
 
-¦`password.encoder.secret`
-a¦The secret used for encoding dynamically configured passwords for this broker.
-¦password
-¦null
-¦
-¦medium
+`password.encoder.secret`::
+*Type:* password +
+*Default:* null +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+The secret used for encoding dynamically configured passwords for this broker.
 
-¦`principal.builder.class`
-a¦The fully qualified name of a class that implements the KafkaPrincipalBuilder interface, which is used to build the KafkaPrincipal object used during authorization. This config also supports the deprecated PrincipalBuilder interface which was previously used for client authentication over SSL. If no principal builder is defined, the default behavior depends on the security protocol in use. For SSL authentication, the principal name will be the distinguished name from the client certificate if one is provided; otherwise, if client authentication is not required, the principal name will be ANONYMOUS. For SASL authentication, the principal will be derived using the rules defined by `sasl.kerberos.principal.to.local.rules` if GSSAPI is in use, and the SASL authentication ID for other mechanisms. For PLAINTEXT, the principal will be ANONYMOUS.
-¦class
-¦null
-¦
-¦medium
+`principal.builder.class`::
+*Type:* class +
+*Default:* null +
+*Importance:* medium +
+*Dynamic update:* per-broker +
++
+The fully qualified name of a class that implements the KafkaPrincipalBuilder interface, which is used to build the KafkaPrincipal object used during authorization. This config also supports the deprecated PrincipalBuilder interface which was previously used for client authentication over SSL. If no principal builder is defined, the default behavior depends on the security protocol in use. For SSL authentication, the principal name will be the distinguished name from the client certificate if one is provided; otherwise, if client authentication is not required, the principal name will be ANONYMOUS. For SASL authentication, the principal will be derived using the rules defined by `sasl.kerberos.principal.to.local.rules` if GSSAPI is in use, and the SASL authentication ID for other mechanisms. For PLAINTEXT, the principal will be ANONYMOUS.
 
-¦`producer.purgatory.purge.interval.requests`
-a¦The purge interval (in number of requests) of the producer request purgatory
-¦int
-¦1000
-¦
-¦medium
+`producer.purgatory.purge.interval.requests`::
+*Type:* int +
+*Default:* 1000 +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+The purge interval (in number of requests) of the producer request purgatory.
 
-¦`queued.max.request.bytes`
-a¦The number of queued bytes allowed before no more requests are read
-¦long
-¦-1
-¦
-¦medium
+`queued.max.request.bytes`::
+*Type:* long +
+*Default:* -1 +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+The number of queued bytes allowed before no more requests are read.
 
-¦`replica.fetch.backoff.ms`
-a¦The amount of time to sleep when fetch partition error occurs.
-¦int
-¦1000
-¦[0,...]
-¦medium
+`replica.fetch.backoff.ms`::
+*Type:* int +
+*Default:* 1000 +
+*Valid Values:* [0,...] +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+The amount of time to sleep when fetch partition error occurs.
 
-¦`replica.fetch.max.bytes`
-a¦The number of bytes of messages to attempt to fetch for each partition. This is not an absolute maximum, if the first record batch in the first non-empty partition of the fetch is larger than this value, the record batch will still be returned to ensure that progress can be made. The maximum record batch size accepted by the broker is defined via `message.max.bytes` (broker config) or `max.message.bytes` (topic config).
-¦int
-¦1048576
-¦[0,...]
-¦medium
+`replica.fetch.max.bytes`::
+*Type:* int +
+*Default:* 1048576 +
+*Valid Values:* [0,...] +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+The number of bytes of messages to attempt to fetch for each partition. This is not an absolute maximum, if the first record batch in the first non-empty partition of the fetch is larger than this value, the record batch will still be returned to ensure that progress can be made. The maximum record batch size accepted by the broker is defined via `message.max.bytes` (broker config) or `max.message.bytes` (topic config).
 
-¦`replica.fetch.response.max.bytes`
-a¦Maximum bytes expected for the entire fetch response. Records are fetched in batches, and if the first record batch in the first non-empty partition of the fetch is larger than this value, the record batch will still be returned to ensure that progress can be made. As such, this is not an absolute maximum. The maximum record batch size accepted by the broker is defined via `message.max.bytes` (broker config) or `max.message.bytes` (topic config).
-¦int
-¦10485760
-¦[0,...]
-¦medium
+`replica.fetch.response.max.bytes`::
+*Type:* int +
+*Default:* 10485760 +
+*Valid Values:* [0,...] +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+Maximum bytes expected for the entire fetch response. Records are fetched in batches, and if the first record batch in the first non-empty partition of the fetch is larger than this value, the record batch will still be returned to ensure that progress can be made. As such, this is not an absolute maximum. The maximum record batch size accepted by the broker is defined via `message.max.bytes` (broker config) or `max.message.bytes` (topic config).
 
-¦`reserved.broker.max.id`
-a¦Max number that can be used for a broker.id
-¦int
-¦1000
-¦[0,...]
-¦medium
+`reserved.broker.max.id`::
+*Type:* int +
+*Default:* 1000 +
+*Valid Values:* [0,...] +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+Max number that can be used for a broker.id.
 
-¦`sasl.client.callback.handler.class`
-a¦The fully qualified name of a SASL client callback handler class that implements the AuthenticateCallbackHandler interface.
-¦class
-¦null
-¦
-¦medium
+`sasl.client.callback.handler.class`::
+*Type:* class +
+*Default:* null +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+The fully qualified name of a SASL client callback handler class that implements the AuthenticateCallbackHandler interface.
 
-¦`sasl.enabled.mechanisms`
-a¦The list of SASL mechanisms enabled in the Kafka server. The list may contain any mechanism for which a security provider is available. Only GSSAPI is enabled by default.
-¦list
-¦GSSAPI
-¦
-¦medium
+`sasl.enabled.mechanisms`::
+*Type:* list +
+*Default:* GSSAPI +
+*Importance:* medium +
+*Dynamic update:* per-broker +
++
+The list of SASL mechanisms enabled in the Kafka server. The list may contain any mechanism for which a security provider is available. Only GSSAPI is enabled by default.
 
-¦`sasl.jaas.config`
-a¦JAAS login context parameters for SASL connections in the format used by JAAS configuration files. JAAS configuration file format is described http://docs.oracle.com/javase/8/docs/technotes/guides/security/jgss/tutorials/LoginConfigFile.html[here]. The format for the value is: '`loginModuleClass controlFlag (optionName=optionValue)*;`'. For brokers, the config must be prefixed with listener prefix and SASL mechanism name in lower-case. For example, listener.name.sasl_ssl.scram-sha-256.sasl.jaas.config=com.example.ScramLoginModule required;
-¦password
-¦null
-¦
-¦medium
+`sasl.jaas.config`::
+*Type:* password +
+*Default:* null +
+*Importance:* medium +
+*Dynamic update:* per-broker +
++
+JAAS login context parameters for SASL connections in the format used by JAAS configuration files. JAAS configuration file format is described http://docs.oracle.com/javase/8/docs/technotes/guides/security/jgss/tutorials/LoginConfigFile.html[here]. The format for the value is: '`loginModuleClass controlFlag (optionName=optionValue)*;`'. For brokers, the config must be prefixed with listener prefix and SASL mechanism name in lower-case. For example, listener.name.sasl_ssl.scram-sha-256.sasl.jaas.config=com.example.ScramLoginModule required;.
 
-¦`sasl.kerberos.kinit.cmd`
-a¦Kerberos kinit command path.
-¦string
-¦/usr/bin/kinit
-¦
-¦medium
+`sasl.kerberos.kinit.cmd`::
+*Type:* string +
+*Default:* /usr/bin/kinit +
+*Importance:* medium +
+*Dynamic update:* per-broker +
++
+Kerberos kinit command path.
 
-¦`sasl.kerberos.min.time.before.relogin`
-a¦Login thread sleep time between refresh attempts.
-¦long
-¦60000
-¦
-¦medium
+`sasl.kerberos.min.time.before.relogin`::
+*Type:* long +
+*Default:* 60000 +
+*Importance:* medium +
+*Dynamic update:* per-broker +
++
+Login thread sleep time between refresh attempts.
 
-¦`sasl.kerberos.principal.to.local.rules`
-a¦A list of rules for mapping from principal names to short names (typically operating system usernames). The rules are evaluated in order and the first rule that matches a principal name is used to map it to a short name. Any later rules in the list are ignored. By default, principal names of the form {username}/{hostname}@{REALM} are mapped to {username}. For more details on the format please see #security_authz[ security authorization and acls]. Note that this configuration is ignored if an extension of KafkaPrincipalBuilder is provided by the `principal.builder.class` configuration.
-¦list
-¦DEFAULT
-¦
-¦medium
+`sasl.kerberos.principal.to.local.rules`::
+*Type:* list +
+*Default:* DEFAULT +
+*Importance:* medium +
+*Dynamic update:* per-broker +
++
+A list of rules for mapping from principal names to short names (typically operating system usernames). The rules are evaluated in order and the first rule that matches a principal name is used to map it to a short name. Any later rules in the list are ignored. By default, principal names of the form {username}/{hostname}@{REALM} are mapped to {username}. For more details on the format please see #security_authz[ security authorization and acls]. Note that this configuration is ignored if an extension of KafkaPrincipalBuilder is provided by the `principal.builder.class` configuration.
 
-¦`sasl.kerberos.service.name`
-a¦The Kerberos principal name that Kafka runs as. This can be defined either in Kafka's JAAS config or in Kafka's config.
-¦string
-¦null
-¦
-¦medium
+`sasl.kerberos.service.name`::
+*Type:* string +
+*Default:* null +
+*Importance:* medium +
+*Dynamic update:* per-broker +
++
+The Kerberos principal name that Kafka runs as. This can be defined either in Kafka's JAAS config or in Kafka's config.
 
-¦`sasl.kerberos.ticket.renew.jitter`
-a¦Percentage of random jitter added to the renewal time.
-¦double
-¦0.05
-¦
-¦medium
+`sasl.kerberos.ticket.renew.jitter`::
+*Type:* double +
+*Default:* 0.05 +
+*Importance:* medium +
+*Dynamic update:* per-broker +
++
+Percentage of random jitter added to the renewal time.
 
-¦`sasl.kerberos.ticket.renew.window.factor`
-a¦Login thread will sleep until the specified window factor of time from last refresh to ticket's expiry has been reached, at which time it will try to renew the ticket.
-¦double
-¦0.8
-¦
-¦medium
+`sasl.kerberos.ticket.renew.window.factor`::
+*Type:* double +
+*Default:* 0.8 +
+*Importance:* medium +
+*Dynamic update:* per-broker +
++
+Login thread will sleep until the specified window factor of time from last refresh to ticket's expiry has been reached, at which time it will try to renew the ticket.
 
-¦`sasl.login.callback.handler.class`
-a¦The fully qualified name of a SASL login callback handler class that implements the AuthenticateCallbackHandler interface. For brokers, login callback handler config must be prefixed with listener prefix and SASL mechanism name in lower-case. For example, listener.name.sasl_ssl.scram-sha-256.sasl.login.callback.handler.class=com.example.CustomScramLoginCallbackHandler
-¦class
-¦null
-¦
-¦medium
+`sasl.login.callback.handler.class`::
+*Type:* class +
+*Default:* null +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+The fully qualified name of a SASL login callback handler class that implements the AuthenticateCallbackHandler interface. For brokers, login callback handler config must be prefixed with listener prefix and SASL mechanism name in lower-case. For example, listener.name.sasl_ssl.scram-sha-256.sasl.login.callback.handler.class=com.example.CustomScramLoginCallbackHandler.
 
-¦`sasl.login.class`
-a¦The fully qualified name of a class that implements the Login interface. For brokers, login config must be prefixed with listener prefix and SASL mechanism name in lower-case. For example, listener.name.sasl_ssl.scram-sha-256.sasl.login.class=com.example.CustomScramLogin
-¦class
-¦null
-¦
-¦medium
+`sasl.login.class`::
+*Type:* class +
+*Default:* null +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+The fully qualified name of a class that implements the Login interface. For brokers, login config must be prefixed with listener prefix and SASL mechanism name in lower-case. For example, listener.name.sasl_ssl.scram-sha-256.sasl.login.class=com.example.CustomScramLogin.
 
-¦`sasl.login.refresh.buffer.seconds`
-a¦The amount of buffer time before credential expiration to maintain when refreshing a credential, in seconds. If a refresh would otherwise occur closer to expiration than the number of buffer seconds then the refresh will be moved up to maintain as much of the buffer time as possible. Legal values are between 0 and 3600 (1 hour); a default value of  300 (5 minutes) is used if no value is specified. This value and sasl.login.refresh.min.period.seconds are both ignored if their sum exceeds the remaining lifetime of a credential. Currently applies only to OAUTHBEARER.
-¦short
-¦300
-¦
-¦medium
+`sasl.login.refresh.buffer.seconds`::
+*Type:* short +
+*Default:* 300 +
+*Importance:* medium +
+*Dynamic update:* per-broker +
++
+The amount of buffer time before credential expiration to maintain when refreshing a credential, in seconds. If a refresh would otherwise occur closer to expiration than the number of buffer seconds then the refresh will be moved up to maintain as much of the buffer time as possible. Legal values are between 0 and 3600 (1 hour); a default value of  300 (5 minutes) is used if no value is specified. This value and sasl.login.refresh.min.period.seconds are both ignored if their sum exceeds the remaining lifetime of a credential. Currently applies only to OAUTHBEARER.
 
-¦`sasl.login.refresh.min.period.seconds`
-a¦The desired minimum time for the login refresh thread to wait before refreshing a credential, in seconds. Legal values are between 0 and 900 (15 minutes); a default value of 60 (1 minute) is used if no value is specified.  This value and  sasl.login.refresh.buffer.seconds are both ignored if their sum exceeds the remaining lifetime of a credential. Currently applies only to OAUTHBEARER.
-¦short
-¦60
-¦
-¦medium
+`sasl.login.refresh.min.period.seconds`::
+*Type:* short +
+*Default:* 60 +
+*Importance:* medium +
+*Dynamic update:* per-broker +
++
+The desired minimum time for the login refresh thread to wait before refreshing a credential, in seconds. Legal values are between 0 and 900 (15 minutes); a default value of 60 (1 minute) is used if no value is specified.  This value and  sasl.login.refresh.buffer.seconds are both ignored if their sum exceeds the remaining lifetime of a credential. Currently applies only to OAUTHBEARER.
 
-¦`sasl.login.refresh.window.factor`
-a¦Login refresh thread will sleep until the specified window factor relative to the credential's lifetime has been reached, at which time it will try to refresh the credential. Legal values are between 0.5 (50%) and 1.0 (100%) inclusive; a default value of 0.8 (80%) is used if no value is specified. Currently applies only to OAUTHBEARER.
-¦double
-¦0.8
-¦
-¦medium
+`sasl.login.refresh.window.factor`::
+*Type:* double +
+*Default:* 0.8 +
+*Importance:* medium +
+*Dynamic update:* per-broker +
++
+Login refresh thread will sleep until the specified window factor relative to the credential's lifetime has been reached, at which time it will try to refresh the credential. Legal values are between 0.5 (50%) and 1.0 (100%) inclusive; a default value of 0.8 (80%) is used if no value is specified. Currently applies only to OAUTHBEARER.
 
-¦`sasl.login.refresh.window.jitter`
-a¦The maximum amount of random jitter relative to the credential's lifetime that is added to the login refresh thread's sleep time. Legal values are between 0 and 0.25 (25%) inclusive; a default value of 0.05 (5%) is used if no value is specified. Currently applies only to OAUTHBEARER.
-¦double
-¦0.05
-¦
-¦medium
+`sasl.login.refresh.window.jitter`::
+*Type:* double +
+*Default:* 0.05 +
+*Importance:* medium +
+*Dynamic update:* per-broker +
++
+The maximum amount of random jitter relative to the credential's lifetime that is added to the login refresh thread's sleep time. Legal values are between 0 and 0.25 (25%) inclusive; a default value of 0.05 (5%) is used if no value is specified. Currently applies only to OAUTHBEARER.
 
-¦`sasl.mechanism.inter.broker.protocol`
-a¦SASL mechanism used for inter-broker communication. Default is GSSAPI.
-¦string
-¦GSSAPI
-¦
-¦medium
+`sasl.mechanism.inter.broker.protocol`::
+*Type:* string +
+*Default:* GSSAPI +
+*Importance:* medium +
+*Dynamic update:* per-broker +
++
+SASL mechanism used for inter-broker communication. Default is GSSAPI.
 
-¦`sasl.server.callback.handler.class`
-a¦The fully qualified name of a SASL server callback handler class that implements the AuthenticateCallbackHandler interface. Server callback handlers must be prefixed with listener prefix and SASL mechanism name in lower-case. For example, listener.name.sasl_ssl.plain.sasl.server.callback.handler.class=com.example.CustomPlainCallbackHandler.
-¦class
-¦null
-¦
-¦medium
+`sasl.server.callback.handler.class`::
+*Type:* class +
+*Default:* null +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+The fully qualified name of a SASL server callback handler class that implements the AuthenticateCallbackHandler interface. Server callback handlers must be prefixed with listener prefix and SASL mechanism name in lower-case. For example, listener.name.sasl_ssl.plain.sasl.server.callback.handler.class=com.example.CustomPlainCallbackHandler.
 
-¦`security.inter.broker.protocol`
-a¦Security protocol used to communicate between brokers. Valid values are: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL. It is an error to set this and inter.broker.listener.name properties at the same time.
-¦string
-¦PLAINTEXT
-¦
-¦medium
+`security.inter.broker.protocol`::
+*Type:* string +
+*Default:* PLAINTEXT +
+*Importance:* medium +
+*Dynamic update:* read-only +
++
+Security protocol used to communicate between brokers. Valid values are: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL. It is an error to set this and inter.broker.listener.name properties at the same time.
 
-¦`ssl.cipher.suites`
-a¦A list of cipher suites. This is a named combination of authentication, encryption, MAC and key exchange algorithm used to negotiate the security settings for a network connection using TLS or SSL network protocol. By default all the available cipher suites are supported.
-¦list
-¦""
-¦
-¦medium
+`ssl.cipher.suites`::
+*Type:* list +
+*Default:* "" +
+*Importance:* medium +
+*Dynamic update:* per-broker +
++
+A list of cipher suites. This is a named combination of authentication, encryption, MAC and key exchange algorithm used to negotiate the security settings for a network connection using TLS or SSL network protocol. By default all the available cipher suites are supported.
 
-¦`ssl.client.auth`
-a¦Configures kafka broker to request client authentication. The following settings are common:  
+`ssl.client.auth`::
+*Type:* string +
+*Default:* none +
+*Valid Values:* [required, requested, none] +
+*Importance:* medium +
+*Dynamic update:* per-broker +
++
+Configures kafka broker to request client authentication. The following settings are common:  
  
 * `ssl.client.auth=required` If set to required client authentication is required. 
 * `ssl.client.auth=requested` This means client authentication is optional. unlike requested , if this option is set client can choose not to provide authentication information about itself 
 * `ssl.client.auth=none` This means client authentication is not needed.
-¦string
-¦none
-¦[required, requested, none]
-¦medium
 
-¦`ssl.enabled.protocols`
-a¦The list of protocols enabled for SSL connections.
-¦list
-¦TLSv1.2,TLSv1.1,TLSv1
-¦
-¦medium
+`ssl.enabled.protocols`::
+*Type:* list +
+*Default:* TLSv1.2,TLSv1.1,TLSv1 +
+*Importance:* medium +
+*Dynamic update:* per-broker +
++
+The list of protocols enabled for SSL connections.
 
-¦`ssl.key.password`
-a¦The password of the private key in the key store file. This is optional for client.
-¦password
-¦null
-¦
-¦medium
+`ssl.key.password`::
+*Type:* password +
+*Default:* null +
+*Importance:* medium +
+*Dynamic update:* per-broker +
++
+The password of the private key in the key store file. This is optional for client.
 
-¦`ssl.keymanager.algorithm`
-a¦The algorithm used by key manager factory for SSL connections. Default value is the key manager factory algorithm configured for the Java Virtual Machine.
-¦string
-¦SunX509
-¦
-¦medium
+`ssl.keymanager.algorithm`::
+*Type:* string +
+*Default:* SunX509 +
+*Importance:* medium +
+*Dynamic update:* per-broker +
++
+The algorithm used by key manager factory for SSL connections. Default value is the key manager factory algorithm configured for the Java Virtual Machine.
 
-¦`ssl.keystore.location`
-a¦The location of the key store file. This is optional for client and can be used for two-way authentication for client.
-¦string
-¦null
-¦
-¦medium
+`ssl.keystore.location`::
+*Type:* string +
+*Default:* null +
+*Importance:* medium +
+*Dynamic update:* per-broker +
++
+The location of the key store file. This is optional for client and can be used for two-way authentication for client.
 
-¦`ssl.keystore.password`
-a¦The store password for the key store file. This is optional for client and only needed if ssl.keystore.location is configured. 
-¦password
-¦null
-¦
-¦medium
+`ssl.keystore.password`::
+*Type:* password +
+*Default:* null +
+*Importance:* medium +
+*Dynamic update:* per-broker +
++
+The store password for the key store file. This is optional for client and only needed if ssl.keystore.location is configured.
 
-¦`ssl.keystore.type`
-a¦The file format of the key store file. This is optional for client.
-¦string
-¦JKS
-¦
-¦medium
+`ssl.keystore.type`::
+*Type:* string +
+*Default:* JKS +
+*Importance:* medium +
+*Dynamic update:* per-broker +
++
+The file format of the key store file. This is optional for client.
 
-¦`ssl.protocol`
-a¦The SSL protocol used to generate the SSLContext. Default setting is TLS, which is fine for most cases. Allowed values in recent JVMs are TLS, TLSv1.1 and TLSv1.2. SSL, SSLv2 and SSLv3 may be supported in older JVMs, but their usage is discouraged due to known security vulnerabilities.
-¦string
-¦TLS
-¦
-¦medium
+`ssl.protocol`::
+*Type:* string +
+*Default:* TLS +
+*Importance:* medium +
+*Dynamic update:* per-broker +
++
+The SSL protocol used to generate the SSLContext. Default setting is TLS, which is fine for most cases. Allowed values in recent JVMs are TLS, TLSv1.1 and TLSv1.2. SSL, SSLv2 and SSLv3 may be supported in older JVMs, but their usage is discouraged due to known security vulnerabilities.
 
-¦`ssl.provider`
-a¦The name of the security provider used for SSL connections. Default value is the default security provider of the JVM.
-¦string
-¦null
-¦
-¦medium
+`ssl.provider`::
+*Type:* string +
+*Default:* null +
+*Importance:* medium +
+*Dynamic update:* per-broker +
++
+The name of the security provider used for SSL connections. Default value is the default security provider of the JVM.
 
-¦`ssl.trustmanager.algorithm`
-a¦The algorithm used by trust manager factory for SSL connections. Default value is the trust manager factory algorithm configured for the Java Virtual Machine.
-¦string
-¦PKIX
-¦
-¦medium
+`ssl.trustmanager.algorithm`::
+*Type:* string +
+*Default:* PKIX +
+*Importance:* medium +
+*Dynamic update:* per-broker +
++
+The algorithm used by trust manager factory for SSL connections. Default value is the trust manager factory algorithm configured for the Java Virtual Machine.
 
-¦`ssl.truststore.location`
-a¦The location of the trust store file. 
-¦string
-¦null
-¦
-¦medium
+`ssl.truststore.location`::
+*Type:* string +
+*Default:* null +
+*Importance:* medium +
+*Dynamic update:* per-broker +
++
+The location of the trust store file.
 
-¦`ssl.truststore.password`
-a¦The password for the trust store file. If a password is not set access to the truststore is still available, but integrity checking is disabled.
-¦password
-¦null
-¦
-¦medium
+`ssl.truststore.password`::
+*Type:* password +
+*Default:* null +
+*Importance:* medium +
+*Dynamic update:* per-broker +
++
+The password for the trust store file. If a password is not set access to the truststore is still available, but integrity checking is disabled.
 
-¦`ssl.truststore.type`
-a¦The file format of the trust store file.
-¦string
-¦JKS
-¦
-¦medium
+`ssl.truststore.type`::
+*Type:* string +
+*Default:* JKS +
+*Importance:* medium +
+*Dynamic update:* per-broker +
++
+The file format of the trust store file.
 
-¦`alter.config.policy.class.name`
-a¦The alter configs policy class that should be used for validation. The class should implement the `org.apache.kafka.server.policy.AlterConfigPolicy` interface.
-¦class
-¦null
-¦
-¦low
+`alter.config.policy.class.name`::
+*Type:* class +
+*Default:* null +
+*Importance:* low +
+*Dynamic update:* read-only +
++
+The alter configs policy class that should be used for validation. The class should implement the `org.apache.kafka.server.policy.AlterConfigPolicy` interface.
 
-¦`alter.log.dirs.replication.quota.window.num`
-a¦The number of samples to retain in memory for alter log dirs replication quotas
-¦int
-¦11
-¦[1,...]
-¦low
+`alter.log.dirs.replication.quota.window.num`::
+*Type:* int +
+*Default:* 11 +
+*Valid Values:* [1,...] +
+*Importance:* low +
+*Dynamic update:* read-only +
++
+The number of samples to retain in memory for alter log dirs replication quotas.
 
-¦`alter.log.dirs.replication.quota.window.size.seconds`
-a¦The time span of each sample for alter log dirs replication quotas
-¦int
-¦1
-¦[1,...]
-¦low
+`alter.log.dirs.replication.quota.window.size.seconds`::
+*Type:* int +
+*Default:* 1 +
+*Valid Values:* [1,...] +
+*Importance:* low +
+*Dynamic update:* read-only +
++
+The time span of each sample for alter log dirs replication quotas.
 
-¦`authorizer.class.name`
-a¦The authorizer class that should be used for authorization
-¦string
-¦""
-¦
-¦low
+`authorizer.class.name`::
+*Type:* string +
+*Default:* "" +
+*Importance:* low +
+*Dynamic update:* read-only +
++
+The authorizer class that should be used for authorization.
 
-¦`client.quota.callback.class`
-a¦The fully qualified name of a class that implements the ClientQuotaCallback interface, which is used to determine quota limits applied to client requests. By default, <user, client-id>, <user> or <client-id> quotas stored in ZooKeeper are applied. For any given request, the most specific quota that matches the user principal of the session and the client-id of the request is applied.
-¦class
-¦null
-¦
-¦low
+`client.quota.callback.class`::
+*Type:* class +
+*Default:* null +
+*Importance:* low +
+*Dynamic update:* read-only +
++
+The fully qualified name of a class that implements the ClientQuotaCallback interface, which is used to determine quota limits applied to client requests. By default, <user, client-id>, <user> or <client-id> quotas stored in ZooKeeper are applied. For any given request, the most specific quota that matches the user principal of the session and the client-id of the request is applied.
 
-¦`create.topic.policy.class.name`
-a¦The create topic policy class that should be used for validation. The class should implement the `org.apache.kafka.server.policy.CreateTopicPolicy` interface.
-¦class
-¦null
-¦
-¦low
+`create.topic.policy.class.name`::
+*Type:* class +
+*Default:* null +
+*Importance:* low +
+*Dynamic update:* read-only +
++
+The create topic policy class that should be used for validation. The class should implement the `org.apache.kafka.server.policy.CreateTopicPolicy` interface.
 
-¦`delegation.token.expiry.check.interval.ms`
-a¦Scan interval to remove expired delegation tokens.
-¦long
-¦3600000
-¦[1,...]
-¦low
+`delegation.token.expiry.check.interval.ms`::
+*Type:* long +
+*Default:* 3600000 +
+*Valid Values:* [1,...] +
+*Importance:* low +
+*Dynamic update:* read-only +
++
+Scan interval to remove expired delegation tokens.
 
-¦`listener.security.protocol.map`
-a¦Map between listener names and security protocols. This must be defined for the same security protocol to be usable in more than one port or IP. For example, internal and external traffic can be separated even if SSL is required for both. Concretely, the user could define listeners with names INTERNAL and EXTERNAL and this property as: `INTERNAL:SSL,EXTERNAL:SSL`. As shown, key and value are separated by a colon and map entries are separated by commas. Each listener name should only appear once in the map. Different security (SSL and SASL) settings can be configured for each listener by adding a normalised prefix (the listener name is lowercased) to the config name. For example, to set a different keystore for the INTERNAL listener, a config with name `listener.name.internal.ssl.keystore.location` would be set. If the config for the listener name is not set, the config will fallback to the generic config (i.e. `ssl.keystore.location`). 
-¦string
-¦PLAINTEXT:PLAINTEXT,SSL:SSL,SASL_PLAINTEXT:SASL_PLAINTEXT,SASL_SSL:SASL_SSL
-¦
-¦low
+`listener.security.protocol.map`::
+*Type:* string +
+*Default:* PLAINTEXT:PLAINTEXT,SSL:SSL,SASL_PLAINTEXT:SASL_PLAINTEXT,SASL_SSL:SASL_SSL +
+*Importance:* low +
+*Dynamic update:* per-broker +
++
+Map between listener names and security protocols. This must be defined for the same security protocol to be usable in more than one port or IP. For example, internal and external traffic can be separated even if SSL is required for both. Concretely, the user could define listeners with names INTERNAL and EXTERNAL and this property as: `INTERNAL:SSL,EXTERNAL:SSL`. As shown, key and value are separated by a colon and map entries are separated by commas. Each listener name should only appear once in the map. Different security (SSL and SASL) settings can be configured for each listener by adding a normalised prefix (the listener name is lowercased) to the config name. For example, to set a different keystore for the INTERNAL listener, a config with name `listener.name.internal.ssl.keystore.location` would be set. If the config for the listener name is not set, the config will fallback to the generic config (i.e. `ssl.keystore.location`).
 
-¦`log.message.downconversion.enable`
-a¦This configuration controls whether down-conversion of message formats is enabled to satisfy consume requests. When set to `false`, broker will not perform down-conversion for consumers expecting an older message format. The broker responds with `UNSUPPORTED_VERSION` error for consume requests from such older clients. This configurationdoes not apply to any message format conversion that might be required for replication to followers.
-¦boolean
-¦true
-¦
-¦low
+`log.message.downconversion.enable`::
+*Type:* boolean +
+*Default:* true +
+*Importance:* low +
+*Dynamic update:* cluster-wide +
++
+This configuration controls whether down-conversion of message formats is enabled to satisfy consume requests. When set to `false`, broker will not perform down-conversion for consumers expecting an older message format. The broker responds with `UNSUPPORTED_VERSION` error for consume requests from such older clients. This configurationdoes not apply to any message format conversion that might be required for replication to followers.
 
-¦`metric.reporters`
-a¦A list of classes to use as metrics reporters. Implementing the `org.apache.kafka.common.metrics.MetricsReporter` interface allows plugging in classes that will be notified of new metric creation. The JmxReporter is always included to register JMX statistics.
-¦list
-¦""
-¦
-¦low
+`metric.reporters`::
+*Type:* list +
+*Default:* "" +
+*Importance:* low +
+*Dynamic update:* cluster-wide +
++
+A list of classes to use as metrics reporters. Implementing the `org.apache.kafka.common.metrics.MetricsReporter` interface allows plugging in classes that will be notified of new metric creation. The JmxReporter is always included to register JMX statistics.
 
-¦`metrics.num.samples`
-a¦The number of samples maintained to compute metrics.
-¦int
-¦2
-¦[1,...]
-¦low
+`metrics.num.samples`::
+*Type:* int +
+*Default:* 2 +
+*Valid Values:* [1,...] +
+*Importance:* low +
+*Dynamic update:* read-only +
++
+The number of samples maintained to compute metrics.
 
-¦`metrics.recording.level`
-a¦The highest recording level for metrics.
-¦string
-¦INFO
-¦
-¦low
+`metrics.recording.level`::
+*Type:* string +
+*Default:* INFO +
+*Importance:* low +
+*Dynamic update:* read-only +
++
+The highest recording level for metrics.
 
-¦`metrics.sample.window.ms`
-a¦The window of time a metrics sample is computed over.
-¦long
-¦30000
-¦[1,...]
-¦low
+`metrics.sample.window.ms`::
+*Type:* long +
+*Default:* 30000 +
+*Valid Values:* [1,...] +
+*Importance:* low +
+*Dynamic update:* read-only +
++
+The window of time a metrics sample is computed over.
 
-¦`password.encoder.cipher.algorithm`
-a¦The Cipher algorithm used for encoding dynamically configured passwords.
-¦string
-¦AES/CBC/PKCS5Padding
-¦
-¦low
+`password.encoder.cipher.algorithm`::
+*Type:* string +
+*Default:* AES/CBC/PKCS5Padding +
+*Importance:* low +
+*Dynamic update:* read-only +
++
+The Cipher algorithm used for encoding dynamically configured passwords.
 
-¦`password.encoder.iterations`
-a¦The iteration count used for encoding dynamically configured passwords.
-¦int
-¦4096
-¦[1024,...]
-¦low
+`password.encoder.iterations`::
+*Type:* int +
+*Default:* 4096 +
+*Valid Values:* [1024,...] +
+*Importance:* low +
+*Dynamic update:* read-only +
++
+The iteration count used for encoding dynamically configured passwords.
 
-¦`password.encoder.key.length`
-a¦The key length used for encoding dynamically configured passwords.
-¦int
-¦128
-¦[8,...]
-¦low
+`password.encoder.key.length`::
+*Type:* int +
+*Default:* 128 +
+*Valid Values:* [8,...] +
+*Importance:* low +
+*Dynamic update:* read-only +
++
+The key length used for encoding dynamically configured passwords.
 
-¦`password.encoder.keyfactory.algorithm`
-a¦The SecretKeyFactory algorithm used for encoding dynamically configured passwords. Default is PBKDF2WithHmacSHA512 if available and PBKDF2WithHmacSHA1 otherwise.
-¦string
-¦null
-¦
-¦low
+`password.encoder.keyfactory.algorithm`::
+*Type:* string +
+*Default:* null +
+*Importance:* low +
+*Dynamic update:* read-only +
++
+The SecretKeyFactory algorithm used for encoding dynamically configured passwords. Default is PBKDF2WithHmacSHA512 if available and PBKDF2WithHmacSHA1 otherwise.
 
-¦`quota.window.num`
-a¦The number of samples to retain in memory for client quotas
-¦int
-¦11
-¦[1,...]
-¦low
+`quota.window.num`::
+*Type:* int +
+*Default:* 11 +
+*Valid Values:* [1,...] +
+*Importance:* low +
+*Dynamic update:* read-only +
++
+The number of samples to retain in memory for client quotas.
 
-¦`quota.window.size.seconds`
-a¦The time span of each sample for client quotas
-¦int
-¦1
-¦[1,...]
-¦low
+`quota.window.size.seconds`::
+*Type:* int +
+*Default:* 1 +
+*Valid Values:* [1,...] +
+*Importance:* low +
+*Dynamic update:* read-only +
++
+The time span of each sample for client quotas.
 
-¦`replication.quota.window.num`
-a¦The number of samples to retain in memory for replication quotas
-¦int
-¦11
-¦[1,...]
-¦low
+`replication.quota.window.num`::
+*Type:* int +
+*Default:* 11 +
+*Valid Values:* [1,...] +
+*Importance:* low +
+*Dynamic update:* read-only +
++
+The number of samples to retain in memory for replication quotas.
 
-¦`replication.quota.window.size.seconds`
-a¦The time span of each sample for replication quotas
-¦int
-¦1
-¦[1,...]
-¦low
+`replication.quota.window.size.seconds`::
+*Type:* int +
+*Default:* 1 +
+*Valid Values:* [1,...] +
+*Importance:* low +
+*Dynamic update:* read-only +
++
+The time span of each sample for replication quotas.
 
-¦`ssl.endpoint.identification.algorithm`
-a¦The endpoint identification algorithm to validate server hostname using server certificate. 
-¦string
-¦https
-¦
-¦low
+`ssl.endpoint.identification.algorithm`::
+*Type:* string +
+*Default:* https +
+*Importance:* low +
+*Dynamic update:* per-broker +
++
+The endpoint identification algorithm to validate server hostname using server certificate.
 
-¦`ssl.secure.random.implementation`
-a¦The SecureRandom PRNG implementation to use for SSL cryptography operations. 
-¦string
-¦null
-¦
-¦low
+`ssl.secure.random.implementation`::
+*Type:* string +
+*Default:* null +
+*Importance:* low +
+*Dynamic update:* per-broker +
++
+The SecureRandom PRNG implementation to use for SSL cryptography operations.
 
-¦`transaction.abort.timed.out.transaction.cleanup.interval.ms`
-a¦The interval at which to rollback transactions that have timed out
-¦int
-¦60000
-¦[1,...]
-¦low
+`transaction.abort.timed.out.transaction.cleanup.interval.ms`::
+*Type:* int +
+*Default:* 60000 +
+*Valid Values:* [1,...] +
+*Importance:* low +
+*Dynamic update:* read-only +
++
+The interval at which to rollback transactions that have timed out.
 
-¦`transaction.remove.expired.transaction.cleanup.interval.ms`
-a¦The interval at which to remove transactions that have expired due to `transactional.id.expiration.ms` passing
-¦int
-¦3600000
-¦[1,...]
-¦low
+`transaction.remove.expired.transaction.cleanup.interval.ms`::
+*Type:* int +
+*Default:* 3600000 +
+*Valid Values:* [1,...] +
+*Importance:* low +
+*Dynamic update:* read-only +
++
+The interval at which to remove transactions that have expired due to `transactional.id.expiration.ms` passing.
 
-¦`zookeeper.sync.time.ms`
-a¦How far a ZK follower can be behind a ZK leader
-¦int
-¦2000
-¦
-¦low
-
-|=====
+`zookeeper.sync.time.ms`::
+*Type:* int +
+*Default:* 2000 +
+*Importance:* low +
+*Dynamic update:* read-only +
++
+How far a ZK follower can be behind a ZK leader.

--- a/books/ref-connect-config.adoc
+++ b/books/ref-connect-config.adoc
@@ -1,570 +1,580 @@
 // Module included in the following assemblies:
 //
 // assembly-overview.adoc
+//
+// THIS FILE IS AUTO-GENERATED. DO NOT EDIT BY HAND
+// Run "make clean buildall" to regenerate.
 
 [id='kafka-connect-configuration-parameters-{context}']
 = Kafka Connect configuration parameters
 
-[cols="6",options="header",separator=¦]
-|=====
-¦Name ¦Description ¦Type ¦Default ¦Valid Values ¦Importance 
+`config.storage.topic`::
+*Type:* string +
+*Importance:* high +
++
+The name of the Kafka topic where connector configurations are stored.
 
-¦`config.storage.topic`
-a¦The name of the Kafka topic where connector configurations are stored
-¦string
-¦
-¦
-¦high
+`group.id`::
+*Type:* string +
+*Importance:* high +
++
+A unique string that identifies the Connect cluster group this worker belongs to.
 
-¦`group.id`
-a¦A unique string that identifies the Connect cluster group this worker belongs to.
-¦string
-¦
-¦
-¦high
+`key.converter`::
+*Type:* class +
+*Importance:* high +
++
+Converter class used to convert between Kafka Connect format and the serialized form that is written to Kafka. This controls the format of the keys in messages written to or read from Kafka, and since this is independent of connectors it allows any connector to work with any serialization format. Examples of common formats include JSON and Avro.
 
-¦`key.converter`
-a¦Converter class used to convert between Kafka Connect format and the serialized form that is written to Kafka. This controls the format of the keys in messages written to or read from Kafka, and since this is independent of connectors it allows any connector to work with any serialization format. Examples of common formats include JSON and Avro.
-¦class
-¦
-¦
-¦high
+`offset.storage.topic`::
+*Type:* string +
+*Importance:* high +
++
+The name of the Kafka topic where connector offsets are stored.
 
-¦`offset.storage.topic`
-a¦The name of the Kafka topic where connector offsets are stored
-¦string
-¦
-¦
-¦high
+`status.storage.topic`::
+*Type:* string +
+*Importance:* high +
++
+The name of the Kafka topic where connector and task status are stored.
 
-¦`status.storage.topic`
-a¦The name of the Kafka topic where connector and task status are stored
-¦string
-¦
-¦
-¦high
+`value.converter`::
+*Type:* class +
+*Importance:* high +
++
+Converter class used to convert between Kafka Connect format and the serialized form that is written to Kafka. This controls the format of the values in messages written to or read from Kafka, and since this is independent of connectors it allows any connector to work with any serialization format. Examples of common formats include JSON and Avro.
 
-¦`value.converter`
-a¦Converter class used to convert between Kafka Connect format and the serialized form that is written to Kafka. This controls the format of the values in messages written to or read from Kafka, and since this is independent of connectors it allows any connector to work with any serialization format. Examples of common formats include JSON and Avro.
-¦class
-¦
-¦
-¦high
+`bootstrap.servers`::
+*Type:* list +
+*Default:* localhost:9092 +
+*Importance:* high +
++
+A list of host/port pairs to use for establishing the initial connection to the Kafka cluster. The client will make use of all servers irrespective of which servers are specified here for bootstrapping&mdash;this list only impacts the initial hosts used to discover the full set of servers. This list should be in the form `host1:port1,host2:port2,...`. Since these servers are just used for the initial connection to discover the full cluster membership (which may change dynamically), this list need not contain the full set of servers (you may want more than one, though, in case a server is down).
 
-¦`bootstrap.servers`
-a¦A list of host/port pairs to use for establishing the initial connection to the Kafka cluster. The client will make use of all servers irrespective of which servers are specified here for bootstrapping&mdash;this list only impacts the initial hosts used to discover the full set of servers. This list should be in the form `host1:port1,host2:port2,...`. Since these servers are just used for the initial connection to discover the full cluster membership (which may change dynamically), this list need not contain the full set of servers (you may want more than one, though, in case a server is down).
-¦list
-¦localhost:9092
-¦
-¦high
+`heartbeat.interval.ms`::
+*Type:* int +
+*Default:* 3000 +
+*Importance:* high +
++
+The expected time between heartbeats to the group coordinator when using Kafka's group management facilities. Heartbeats are used to ensure that the worker's session stays active and to facilitate rebalancing when new members join or leave the group. The value must be set lower than `session.timeout.ms`, but typically should be set no higher than 1/3 of that value. It can be adjusted even lower to control the expected time for normal rebalances.
 
-¦`heartbeat.interval.ms`
-a¦The expected time between heartbeats to the group coordinator when using Kafka's group management facilities. Heartbeats are used to ensure that the worker's session stays active and to facilitate rebalancing when new members join or leave the group. The value must be set lower than `session.timeout.ms`, but typically should be set no higher than 1/3 of that value. It can be adjusted even lower to control the expected time for normal rebalances.
-¦int
-¦3000
-¦
-¦high
+`rebalance.timeout.ms`::
+*Type:* int +
+*Default:* 60000 +
+*Importance:* high +
++
+The maximum allowed time for each worker to join the group once a rebalance has begun. This is basically a limit on the amount of time needed for all tasks to flush any pending data and commit offsets. If the timeout is exceeded, then the worker will be removed from the group, which will cause offset commit failures.
 
-¦`rebalance.timeout.ms`
-a¦The maximum allowed time for each worker to join the group once a rebalance has begun. This is basically a limit on the amount of time needed for all tasks to flush any pending data and commit offsets. If the timeout is exceeded, then the worker will be removed from the group, which will cause offset commit failures.
-¦int
-¦60000
-¦
-¦high
+`session.timeout.ms`::
+*Type:* int +
+*Default:* 10000 +
+*Importance:* high +
++
+The timeout used to detect worker failures. The worker sends periodic heartbeats to indicate its liveness to the broker. If no heartbeats are received by the broker before the expiration of this session timeout, then the broker will remove the worker from the group and initiate a rebalance. Note that the value must be in the allowable range as configured in the broker configuration by `group.min.session.timeout.ms` and `group.max.session.timeout.ms`.
 
-¦`session.timeout.ms`
-a¦The timeout used to detect worker failures. The worker sends periodic heartbeats to indicate its liveness to the broker. If no heartbeats are received by the broker before the expiration of this session timeout, then the broker will remove the worker from the group and initiate a rebalance. Note that the value must be in the allowable range as configured in the broker configuration by `group.min.session.timeout.ms` and `group.max.session.timeout.ms`.
-¦int
-¦10000
-¦
-¦high
+`ssl.key.password`::
+*Type:* password +
+*Default:* null +
+*Importance:* high +
++
+The password of the private key in the key store file. This is optional for client.
 
-¦`ssl.key.password`
-a¦The password of the private key in the key store file. This is optional for client.
-¦password
-¦null
-¦
-¦high
+`ssl.keystore.location`::
+*Type:* string +
+*Default:* null +
+*Importance:* high +
++
+The location of the key store file. This is optional for client and can be used for two-way authentication for client.
 
-¦`ssl.keystore.location`
-a¦The location of the key store file. This is optional for client and can be used for two-way authentication for client.
-¦string
-¦null
-¦
-¦high
+`ssl.keystore.password`::
+*Type:* password +
+*Default:* null +
+*Importance:* high +
++
+The store password for the key store file. This is optional for client and only needed if ssl.keystore.location is configured.
 
-¦`ssl.keystore.password`
-a¦The store password for the key store file. This is optional for client and only needed if ssl.keystore.location is configured. 
-¦password
-¦null
-¦
-¦high
+`ssl.truststore.location`::
+*Type:* string +
+*Default:* null +
+*Importance:* high +
++
+The location of the trust store file.
 
-¦`ssl.truststore.location`
-a¦The location of the trust store file. 
-¦string
-¦null
-¦
-¦high
+`ssl.truststore.password`::
+*Type:* password +
+*Default:* null +
+*Importance:* high +
++
+The password for the trust store file. If a password is not set access to the truststore is still available, but integrity checking is disabled.
 
-¦`ssl.truststore.password`
-a¦The password for the trust store file. If a password is not set access to the truststore is still available, but integrity checking is disabled.
-¦password
-¦null
-¦
-¦high
+`connections.max.idle.ms`::
+*Type:* long +
+*Default:* 540000 +
+*Importance:* medium +
++
+Close idle connections after the number of milliseconds specified by this config.
 
-¦`connections.max.idle.ms`
-a¦Close idle connections after the number of milliseconds specified by this config.
-¦long
-¦540000
-¦
-¦medium
+`receive.buffer.bytes`::
+*Type:* int +
+*Default:* 32768 +
+*Valid Values:* [0,...] +
+*Importance:* medium +
++
+The size of the TCP receive buffer (SO_RCVBUF) to use when reading data. If the value is -1, the OS default will be used.
 
-¦`receive.buffer.bytes`
-a¦The size of the TCP receive buffer (SO_RCVBUF) to use when reading data. If the value is -1, the OS default will be used.
-¦int
-¦32768
-¦[0,...]
-¦medium
+`request.timeout.ms`::
+*Type:* int +
+*Default:* 40000 +
+*Valid Values:* [0,...] +
+*Importance:* medium +
++
+The configuration controls the maximum amount of time the client will wait for the response of a request. If the response is not received before the timeout elapses the client will resend the request if necessary or fail the request if retries are exhausted.
 
-¦`request.timeout.ms`
-a¦The configuration controls the maximum amount of time the client will wait for the response of a request. If the response is not received before the timeout elapses the client will resend the request if necessary or fail the request if retries are exhausted.
-¦int
-¦40000
-¦[0,...]
-¦medium
+`sasl.client.callback.handler.class`::
+*Type:* class +
+*Default:* null +
+*Importance:* medium +
++
+The fully qualified name of a SASL client callback handler class that implements the AuthenticateCallbackHandler interface.
 
-¦`sasl.client.callback.handler.class`
-a¦The fully qualified name of a SASL client callback handler class that implements the AuthenticateCallbackHandler interface.
-¦class
-¦null
-¦
-¦medium
+`sasl.jaas.config`::
+*Type:* password +
+*Default:* null +
+*Importance:* medium +
++
+JAAS login context parameters for SASL connections in the format used by JAAS configuration files. JAAS configuration file format is described http://docs.oracle.com/javase/8/docs/technotes/guides/security/jgss/tutorials/LoginConfigFile.html[here]. The format for the value is: '`loginModuleClass controlFlag (optionName=optionValue)*;`'. For brokers, the config must be prefixed with listener prefix and SASL mechanism name in lower-case. For example, listener.name.sasl_ssl.scram-sha-256.sasl.jaas.config=com.example.ScramLoginModule required;.
 
-¦`sasl.jaas.config`
-a¦JAAS login context parameters for SASL connections in the format used by JAAS configuration files. JAAS configuration file format is described http://docs.oracle.com/javase/8/docs/technotes/guides/security/jgss/tutorials/LoginConfigFile.html[here]. The format for the value is: '`loginModuleClass controlFlag (optionName=optionValue)*;`'. For brokers, the config must be prefixed with listener prefix and SASL mechanism name in lower-case. For example, listener.name.sasl_ssl.scram-sha-256.sasl.jaas.config=com.example.ScramLoginModule required;
-¦password
-¦null
-¦
-¦medium
+`sasl.kerberos.service.name`::
+*Type:* string +
+*Default:* null +
+*Importance:* medium +
++
+The Kerberos principal name that Kafka runs as. This can be defined either in Kafka's JAAS config or in Kafka's config.
 
-¦`sasl.kerberos.service.name`
-a¦The Kerberos principal name that Kafka runs as. This can be defined either in Kafka's JAAS config or in Kafka's config.
-¦string
-¦null
-¦
-¦medium
+`sasl.login.callback.handler.class`::
+*Type:* class +
+*Default:* null +
+*Importance:* medium +
++
+The fully qualified name of a SASL login callback handler class that implements the AuthenticateCallbackHandler interface. For brokers, login callback handler config must be prefixed with listener prefix and SASL mechanism name in lower-case. For example, listener.name.sasl_ssl.scram-sha-256.sasl.login.callback.handler.class=com.example.CustomScramLoginCallbackHandler.
 
-¦`sasl.login.callback.handler.class`
-a¦The fully qualified name of a SASL login callback handler class that implements the AuthenticateCallbackHandler interface. For brokers, login callback handler config must be prefixed with listener prefix and SASL mechanism name in lower-case. For example, listener.name.sasl_ssl.scram-sha-256.sasl.login.callback.handler.class=com.example.CustomScramLoginCallbackHandler
-¦class
-¦null
-¦
-¦medium
+`sasl.login.class`::
+*Type:* class +
+*Default:* null +
+*Importance:* medium +
++
+The fully qualified name of a class that implements the Login interface. For brokers, login config must be prefixed with listener prefix and SASL mechanism name in lower-case. For example, listener.name.sasl_ssl.scram-sha-256.sasl.login.class=com.example.CustomScramLogin.
 
-¦`sasl.login.class`
-a¦The fully qualified name of a class that implements the Login interface. For brokers, login config must be prefixed with listener prefix and SASL mechanism name in lower-case. For example, listener.name.sasl_ssl.scram-sha-256.sasl.login.class=com.example.CustomScramLogin
-¦class
-¦null
-¦
-¦medium
+`sasl.mechanism`::
+*Type:* string +
+*Default:* GSSAPI +
+*Importance:* medium +
++
+SASL mechanism used for client connections. This may be any mechanism for which a security provider is available. GSSAPI is the default mechanism.
 
-¦`sasl.mechanism`
-a¦SASL mechanism used for client connections. This may be any mechanism for which a security provider is available. GSSAPI is the default mechanism.
-¦string
-¦GSSAPI
-¦
-¦medium
+`security.protocol`::
+*Type:* string +
+*Default:* PLAINTEXT +
+*Importance:* medium +
++
+Protocol used to communicate with brokers. Valid values are: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL.
 
-¦`security.protocol`
-a¦Protocol used to communicate with brokers. Valid values are: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL.
-¦string
-¦PLAINTEXT
-¦
-¦medium
+`send.buffer.bytes`::
+*Type:* int +
+*Default:* 131072 +
+*Valid Values:* [0,...] +
+*Importance:* medium +
++
+The size of the TCP send buffer (SO_SNDBUF) to use when sending data. If the value is -1, the OS default will be used.
 
-¦`send.buffer.bytes`
-a¦The size of the TCP send buffer (SO_SNDBUF) to use when sending data. If the value is -1, the OS default will be used.
-¦int
-¦131072
-¦[0,...]
-¦medium
+`ssl.enabled.protocols`::
+*Type:* list +
+*Default:* TLSv1.2,TLSv1.1,TLSv1 +
+*Importance:* medium +
++
+The list of protocols enabled for SSL connections.
 
-¦`ssl.enabled.protocols`
-a¦The list of protocols enabled for SSL connections.
-¦list
-¦TLSv1.2,TLSv1.1,TLSv1
-¦
-¦medium
+`ssl.keystore.type`::
+*Type:* string +
+*Default:* JKS +
+*Importance:* medium +
++
+The file format of the key store file. This is optional for client.
 
-¦`ssl.keystore.type`
-a¦The file format of the key store file. This is optional for client.
-¦string
-¦JKS
-¦
-¦medium
+`ssl.protocol`::
+*Type:* string +
+*Default:* TLS +
+*Importance:* medium +
++
+The SSL protocol used to generate the SSLContext. Default setting is TLS, which is fine for most cases. Allowed values in recent JVMs are TLS, TLSv1.1 and TLSv1.2. SSL, SSLv2 and SSLv3 may be supported in older JVMs, but their usage is discouraged due to known security vulnerabilities.
 
-¦`ssl.protocol`
-a¦The SSL protocol used to generate the SSLContext. Default setting is TLS, which is fine for most cases. Allowed values in recent JVMs are TLS, TLSv1.1 and TLSv1.2. SSL, SSLv2 and SSLv3 may be supported in older JVMs, but their usage is discouraged due to known security vulnerabilities.
-¦string
-¦TLS
-¦
-¦medium
+`ssl.provider`::
+*Type:* string +
+*Default:* null +
+*Importance:* medium +
++
+The name of the security provider used for SSL connections. Default value is the default security provider of the JVM.
 
-¦`ssl.provider`
-a¦The name of the security provider used for SSL connections. Default value is the default security provider of the JVM.
-¦string
-¦null
-¦
-¦medium
+`ssl.truststore.type`::
+*Type:* string +
+*Default:* JKS +
+*Importance:* medium +
++
+The file format of the trust store file.
 
-¦`ssl.truststore.type`
-a¦The file format of the trust store file.
-¦string
-¦JKS
-¦
-¦medium
+`worker.sync.timeout.ms`::
+*Type:* int +
+*Default:* 3000 +
+*Importance:* medium +
++
+When the worker is out of sync with other workers and needs to resynchronize configurations, wait up to this amount of time before giving up, leaving the group, and waiting a backoff period before rejoining.
 
-¦`worker.sync.timeout.ms`
-a¦When the worker is out of sync with other workers and needs to resynchronize configurations, wait up to this amount of time before giving up, leaving the group, and waiting a backoff period before rejoining.
-¦int
-¦3000
-¦
-¦medium
+`worker.unsync.backoff.ms`::
+*Type:* int +
+*Default:* 300000 +
+*Importance:* medium +
++
+When the worker is out of sync with other workers and  fails to catch up within worker.sync.timeout.ms, leave the Connect cluster for this long before rejoining.
 
-¦`worker.unsync.backoff.ms`
-a¦When the worker is out of sync with other workers and  fails to catch up within worker.sync.timeout.ms, leave the Connect cluster for this long before rejoining.
-¦int
-¦300000
-¦
-¦medium
+`access.control.allow.methods`::
+*Type:* string +
+*Default:* "" +
+*Importance:* low +
++
+Sets the methods supported for cross origin requests by setting the Access-Control-Allow-Methods header. The default value of the Access-Control-Allow-Methods header allows cross origin requests for GET, POST and HEAD.
 
-¦`access.control.allow.methods`
-a¦Sets the methods supported for cross origin requests by setting the Access-Control-Allow-Methods header. The default value of the Access-Control-Allow-Methods header allows cross origin requests for GET, POST and HEAD.
-¦string
-¦""
-¦
-¦low
+`access.control.allow.origin`::
+*Type:* string +
+*Default:* "" +
+*Importance:* low +
++
+Value to set the Access-Control-Allow-Origin header to for REST API requests.To enable cross origin access, set this to the domain of the application that should be permitted to access the API, or '*' to allow access from any domain. The default value only allows access from the domain of the REST API.
 
-¦`access.control.allow.origin`
-a¦Value to set the Access-Control-Allow-Origin header to for REST API requests.To enable cross origin access, set this to the domain of the application that should be permitted to access the API, or '*' to allow access from any domain. The default value only allows access from the domain of the REST API.
-¦string
-¦""
-¦
-¦low
+`client.id`::
+*Type:* string +
+*Default:* "" +
+*Importance:* low +
++
+An id string to pass to the server when making requests. The purpose of this is to be able to track the source of requests beyond just ip/port by allowing a logical application name to be included in server-side request logging.
 
-¦`client.id`
-a¦An id string to pass to the server when making requests. The purpose of this is to be able to track the source of requests beyond just ip/port by allowing a logical application name to be included in server-side request logging.
-¦string
-¦""
-¦
-¦low
+`config.providers`::
+*Type:* list +
+*Default:* "" +
+*Importance:* low +
++
+Comma-separated names of `ConfigProvider` classes, loaded and used in the order specified. Implementing the interface  `ConfigProvider` allows you to replace variable references in connector configurations, such as for externalized secrets.
 
-¦`config.providers`
-a¦Comma-separated names of `ConfigProvider` classes, loaded and used in the order specified. Implementing the interface  `ConfigProvider` allows you to replace variable references in connector configurations, such as for externalized secrets. 
-¦list
-¦""
-¦
-¦low
+`config.storage.replication.factor`::
+*Type:* short +
+*Default:* 3 +
+*Valid Values:* [1,...] +
+*Importance:* low +
++
+Replication factor used when creating the configuration storage topic.
 
-¦`config.storage.replication.factor`
-a¦Replication factor used when creating the configuration storage topic
-¦short
-¦3
-¦[1,...]
-¦low
+`header.converter`::
+*Type:* class +
+*Default:* org.apache.kafka.connect.storage.SimpleHeaderConverter +
+*Importance:* low +
++
+HeaderConverter class used to convert between Kafka Connect format and the serialized form that is written to Kafka. This controls the format of the header values in messages written to or read from Kafka, and since this is independent of connectors it allows any connector to work with any serialization format. Examples of common formats include JSON and Avro. By default, the SimpleHeaderConverter is used to serialize header values to strings and deserialize them by inferring the schemas.
 
-¦`header.converter`
-a¦HeaderConverter class used to convert between Kafka Connect format and the serialized form that is written to Kafka. This controls the format of the header values in messages written to or read from Kafka, and since this is independent of connectors it allows any connector to work with any serialization format. Examples of common formats include JSON and Avro. By default, the SimpleHeaderConverter is used to serialize header values to strings and deserialize them by inferring the schemas.
-¦class
-¦org.apache.kafka.connect.storage.SimpleHeaderConverter
-¦
-¦low
+`internal.key.converter`::
+*Type:* class +
+*Default:* org.apache.kafka.connect.json.JsonConverter +
+*Importance:* low +
++
+Converter class used to convert between Kafka Connect format and the serialized form that is written to Kafka. This controls the format of the keys in messages written to or read from Kafka, and since this is independent of connectors it allows any connector to work with any serialization format. Examples of common formats include JSON and Avro. This setting controls the format used for internal bookkeeping data used by the framework, such as configs and offsets, so users can typically use any functioning Converter implementation. Deprecated; will be removed in an upcoming version.
 
-¦`internal.key.converter`
-a¦Converter class used to convert between Kafka Connect format and the serialized form that is written to Kafka. This controls the format of the keys in messages written to or read from Kafka, and since this is independent of connectors it allows any connector to work with any serialization format. Examples of common formats include JSON and Avro. This setting controls the format used for internal bookkeeping data used by the framework, such as configs and offsets, so users can typically use any functioning Converter implementation. Deprecated; will be removed in an upcoming version.
-¦class
-¦org.apache.kafka.connect.json.JsonConverter
-¦
-¦low
+`internal.value.converter`::
+*Type:* class +
+*Default:* org.apache.kafka.connect.json.JsonConverter +
+*Importance:* low +
++
+Converter class used to convert between Kafka Connect format and the serialized form that is written to Kafka. This controls the format of the values in messages written to or read from Kafka, and since this is independent of connectors it allows any connector to work with any serialization format. Examples of common formats include JSON and Avro. This setting controls the format used for internal bookkeeping data used by the framework, such as configs and offsets, so users can typically use any functioning Converter implementation. Deprecated; will be removed in an upcoming version.
 
-¦`internal.value.converter`
-a¦Converter class used to convert between Kafka Connect format and the serialized form that is written to Kafka. This controls the format of the values in messages written to or read from Kafka, and since this is independent of connectors it allows any connector to work with any serialization format. Examples of common formats include JSON and Avro. This setting controls the format used for internal bookkeeping data used by the framework, such as configs and offsets, so users can typically use any functioning Converter implementation. Deprecated; will be removed in an upcoming version.
-¦class
-¦org.apache.kafka.connect.json.JsonConverter
-¦
-¦low
-
-¦`listeners`
-a¦List of comma-separated URIs the REST API will listen on. The supported protocols are HTTP and HTTPS.
+`listeners`::
+*Type:* list +
+*Default:* null +
+*Importance:* low +
++
+List of comma-separated URIs the REST API will listen on. The supported protocols are HTTP and HTTPS.
  Specify hostname as 0.0.0.0 to bind to all interfaces.
  Leave hostname empty to bind to default interface.
- Examples of legal listener lists: HTTP://myhost:8083,HTTPS://myhost:8084
-¦list
-¦null
-¦
-¦low
+ Examples of legal listener lists: HTTP://myhost:8083,HTTPS://myhost:8084.
 
-¦`metadata.max.age.ms`
-a¦The period of time in milliseconds after which we force a refresh of metadata even if we haven't seen any partition leadership changes to proactively discover any new brokers or partitions.
-¦long
-¦300000
-¦[0,...]
-¦low
+`metadata.max.age.ms`::
+*Type:* long +
+*Default:* 300000 +
+*Valid Values:* [0,...] +
+*Importance:* low +
++
+The period of time in milliseconds after which we force a refresh of metadata even if we haven't seen any partition leadership changes to proactively discover any new brokers or partitions.
 
-¦`metric.reporters`
-a¦A list of classes to use as metrics reporters. Implementing the `org.apache.kafka.common.metrics.MetricsReporter` interface allows plugging in classes that will be notified of new metric creation. The JmxReporter is always included to register JMX statistics.
-¦list
-¦""
-¦
-¦low
+`metric.reporters`::
+*Type:* list +
+*Default:* "" +
+*Importance:* low +
++
+A list of classes to use as metrics reporters. Implementing the `org.apache.kafka.common.metrics.MetricsReporter` interface allows plugging in classes that will be notified of new metric creation. The JmxReporter is always included to register JMX statistics.
 
-¦`metrics.num.samples`
-a¦The number of samples maintained to compute metrics.
-¦int
-¦2
-¦[1,...]
-¦low
+`metrics.num.samples`::
+*Type:* int +
+*Default:* 2 +
+*Valid Values:* [1,...] +
+*Importance:* low +
++
+The number of samples maintained to compute metrics.
 
-¦`metrics.recording.level`
-a¦The highest recording level for metrics.
-¦string
-¦INFO
-¦[INFO, DEBUG]
-¦low
+`metrics.recording.level`::
+*Type:* string +
+*Default:* INFO +
+*Valid Values:* [INFO, DEBUG] +
+*Importance:* low +
++
+The highest recording level for metrics.
 
-¦`metrics.sample.window.ms`
-a¦The window of time a metrics sample is computed over.
-¦long
-¦30000
-¦[0,...]
-¦low
+`metrics.sample.window.ms`::
+*Type:* long +
+*Default:* 30000 +
+*Valid Values:* [0,...] +
+*Importance:* low +
++
+The window of time a metrics sample is computed over.
 
-¦`offset.flush.interval.ms`
-a¦Interval at which to try committing offsets for tasks.
-¦long
-¦60000
-¦
-¦low
+`offset.flush.interval.ms`::
+*Type:* long +
+*Default:* 60000 +
+*Importance:* low +
++
+Interval at which to try committing offsets for tasks.
 
-¦`offset.flush.timeout.ms`
-a¦Maximum number of milliseconds to wait for records to flush and partition offset data to be committed to offset storage before cancelling the process and restoring the offset data to be committed in a future attempt.
-¦long
-¦5000
-¦
-¦low
+`offset.flush.timeout.ms`::
+*Type:* long +
+*Default:* 5000 +
+*Importance:* low +
++
+Maximum number of milliseconds to wait for records to flush and partition offset data to be committed to offset storage before cancelling the process and restoring the offset data to be committed in a future attempt.
 
-¦`offset.storage.partitions`
-a¦The number of partitions used when creating the offset storage topic
-¦int
-¦25
-¦[1,...]
-¦low
+`offset.storage.partitions`::
+*Type:* int +
+*Default:* 25 +
+*Valid Values:* [1,...] +
+*Importance:* low +
++
+The number of partitions used when creating the offset storage topic.
 
-¦`offset.storage.replication.factor`
-a¦Replication factor used when creating the offset storage topic
-¦short
-¦3
-¦[1,...]
-¦low
+`offset.storage.replication.factor`::
+*Type:* short +
+*Default:* 3 +
+*Valid Values:* [1,...] +
+*Importance:* low +
++
+Replication factor used when creating the offset storage topic.
 
-¦`plugin.path`
-a¦List of paths separated by commas (,) that contain plugins (connectors, converters, transformations). The list should consist of top level directories that include any combination of: 
+`plugin.path`::
+*Type:* list +
+*Default:* null +
+*Importance:* low +
++
+List of paths separated by commas (,) that contain plugins (connectors, converters, transformations). The list should consist of top level directories that include any combination of: 
 a) directories immediately containing jars with plugins and their dependencies
 b) uber-jars with plugins and their dependencies
 c) directories immediately containing the package directory structure of classes of plugins and their dependencies
 Note: symlinks will be followed to discover dependencies or plugins.
-Examples: plugin.path=/usr/local/share/java,/usr/local/share/kafka/plugins,/opt/connectors
-¦list
-¦null
-¦
-¦low
+Examples: plugin.path=/usr/local/share/java,/usr/local/share/kafka/plugins,/opt/connectors.
 
-¦`reconnect.backoff.max.ms`
-a¦The maximum amount of time in milliseconds to wait when reconnecting to a broker that has repeatedly failed to connect. If provided, the backoff per host will increase exponentially for each consecutive connection failure, up to this maximum. After calculating the backoff increase, 20% random jitter is added to avoid connection storms.
-¦long
-¦1000
-¦[0,...]
-¦low
+`reconnect.backoff.max.ms`::
+*Type:* long +
+*Default:* 1000 +
+*Valid Values:* [0,...] +
+*Importance:* low +
++
+The maximum amount of time in milliseconds to wait when reconnecting to a broker that has repeatedly failed to connect. If provided, the backoff per host will increase exponentially for each consecutive connection failure, up to this maximum. After calculating the backoff increase, 20% random jitter is added to avoid connection storms.
 
-¦`reconnect.backoff.ms`
-a¦The base amount of time to wait before attempting to reconnect to a given host. This avoids repeatedly connecting to a host in a tight loop. This backoff applies to all connection attempts by the client to a broker.
-¦long
-¦50
-¦[0,...]
-¦low
+`reconnect.backoff.ms`::
+*Type:* long +
+*Default:* 50 +
+*Valid Values:* [0,...] +
+*Importance:* low +
++
+The base amount of time to wait before attempting to reconnect to a given host. This avoids repeatedly connecting to a host in a tight loop. This backoff applies to all connection attempts by the client to a broker.
 
-¦`rest.advertised.host.name`
-a¦If this is set, this is the hostname that will be given out to other workers to connect to.
-¦string
-¦null
-¦
-¦low
+`rest.advertised.host.name`::
+*Type:* string +
+*Default:* null +
+*Importance:* low +
++
+If this is set, this is the hostname that will be given out to other workers to connect to.
 
-¦`rest.advertised.listener`
-a¦Sets the advertised listener (HTTP or HTTPS) which will be given to other workers to use.
-¦string
-¦null
-¦
-¦low
+`rest.advertised.listener`::
+*Type:* string +
+*Default:* null +
+*Importance:* low +
++
+Sets the advertised listener (HTTP or HTTPS) which will be given to other workers to use.
 
-¦`rest.advertised.port`
-a¦If this is set, this is the port that will be given out to other workers to connect to.
-¦int
-¦null
-¦
-¦low
+`rest.advertised.port`::
+*Type:* int +
+*Default:* null +
+*Importance:* low +
++
+If this is set, this is the port that will be given out to other workers to connect to.
 
-¦`rest.extension.classes`
-a¦Comma-separated names of `ConnectRestExtension` classes, loaded and called in the order specified. Implementing the interface  `ConnectRestExtension` allows you to inject into Connect's REST API user defined resources like filters. Typically used to add custom capability like logging, security, etc. 
-¦list
-¦""
-¦
-¦low
+`rest.extension.classes`::
+*Type:* list +
+*Default:* "" +
+*Importance:* low +
++
+Comma-separated names of `ConnectRestExtension` classes, loaded and called in the order specified. Implementing the interface  `ConnectRestExtension` allows you to inject into Connect's REST API user defined resources like filters. Typically used to add custom capability like logging, security, etc.
 
-¦`rest.host.name`
-a¦Hostname for the REST API. If this is set, it will only bind to this interface.
-¦string
-¦null
-¦
-¦low
+`rest.host.name`::
+*Type:* string +
+*Default:* null +
+*Importance:* low +
++
+Hostname for the REST API. If this is set, it will only bind to this interface.
 
-¦`rest.port`
-a¦Port for the REST API to listen on.
-¦int
-¦8083
-¦
-¦low
+`rest.port`::
+*Type:* int +
+*Default:* 8083 +
+*Importance:* low +
++
+Port for the REST API to listen on.
 
-¦`retry.backoff.ms`
-a¦The amount of time to wait before attempting to retry a failed request to a given topic partition. This avoids repeatedly sending requests in a tight loop under some failure scenarios.
-¦long
-¦100
-¦[0,...]
-¦low
+`retry.backoff.ms`::
+*Type:* long +
+*Default:* 100 +
+*Valid Values:* [0,...] +
+*Importance:* low +
++
+The amount of time to wait before attempting to retry a failed request to a given topic partition. This avoids repeatedly sending requests in a tight loop under some failure scenarios.
 
-¦`sasl.kerberos.kinit.cmd`
-a¦Kerberos kinit command path.
-¦string
-¦/usr/bin/kinit
-¦
-¦low
+`sasl.kerberos.kinit.cmd`::
+*Type:* string +
+*Default:* /usr/bin/kinit +
+*Importance:* low +
++
+Kerberos kinit command path.
 
-¦`sasl.kerberos.min.time.before.relogin`
-a¦Login thread sleep time between refresh attempts.
-¦long
-¦60000
-¦
-¦low
+`sasl.kerberos.min.time.before.relogin`::
+*Type:* long +
+*Default:* 60000 +
+*Importance:* low +
++
+Login thread sleep time between refresh attempts.
 
-¦`sasl.kerberos.ticket.renew.jitter`
-a¦Percentage of random jitter added to the renewal time.
-¦double
-¦0.05
-¦
-¦low
+`sasl.kerberos.ticket.renew.jitter`::
+*Type:* double +
+*Default:* 0.05 +
+*Importance:* low +
++
+Percentage of random jitter added to the renewal time.
 
-¦`sasl.kerberos.ticket.renew.window.factor`
-a¦Login thread will sleep until the specified window factor of time from last refresh to ticket's expiry has been reached, at which time it will try to renew the ticket.
-¦double
-¦0.8
-¦
-¦low
+`sasl.kerberos.ticket.renew.window.factor`::
+*Type:* double +
+*Default:* 0.8 +
+*Importance:* low +
++
+Login thread will sleep until the specified window factor of time from last refresh to ticket's expiry has been reached, at which time it will try to renew the ticket.
 
-¦`sasl.login.refresh.buffer.seconds`
-a¦The amount of buffer time before credential expiration to maintain when refreshing a credential, in seconds. If a refresh would otherwise occur closer to expiration than the number of buffer seconds then the refresh will be moved up to maintain as much of the buffer time as possible. Legal values are between 0 and 3600 (1 hour); a default value of  300 (5 minutes) is used if no value is specified. This value and sasl.login.refresh.min.period.seconds are both ignored if their sum exceeds the remaining lifetime of a credential. Currently applies only to OAUTHBEARER.
-¦short
-¦300
-¦[0,...,3600]
-¦low
+`sasl.login.refresh.buffer.seconds`::
+*Type:* short +
+*Default:* 300 +
+*Valid Values:* [0,...,3600] +
+*Importance:* low +
++
+The amount of buffer time before credential expiration to maintain when refreshing a credential, in seconds. If a refresh would otherwise occur closer to expiration than the number of buffer seconds then the refresh will be moved up to maintain as much of the buffer time as possible. Legal values are between 0 and 3600 (1 hour); a default value of  300 (5 minutes) is used if no value is specified. This value and sasl.login.refresh.min.period.seconds are both ignored if their sum exceeds the remaining lifetime of a credential. Currently applies only to OAUTHBEARER.
 
-¦`sasl.login.refresh.min.period.seconds`
-a¦The desired minimum time for the login refresh thread to wait before refreshing a credential, in seconds. Legal values are between 0 and 900 (15 minutes); a default value of 60 (1 minute) is used if no value is specified.  This value and  sasl.login.refresh.buffer.seconds are both ignored if their sum exceeds the remaining lifetime of a credential. Currently applies only to OAUTHBEARER.
-¦short
-¦60
-¦[0,...,900]
-¦low
+`sasl.login.refresh.min.period.seconds`::
+*Type:* short +
+*Default:* 60 +
+*Valid Values:* [0,...,900] +
+*Importance:* low +
++
+The desired minimum time for the login refresh thread to wait before refreshing a credential, in seconds. Legal values are between 0 and 900 (15 minutes); a default value of 60 (1 minute) is used if no value is specified.  This value and  sasl.login.refresh.buffer.seconds are both ignored if their sum exceeds the remaining lifetime of a credential. Currently applies only to OAUTHBEARER.
 
-¦`sasl.login.refresh.window.factor`
-a¦Login refresh thread will sleep until the specified window factor relative to the credential's lifetime has been reached, at which time it will try to refresh the credential. Legal values are between 0.5 (50%) and 1.0 (100%) inclusive; a default value of 0.8 (80%) is used if no value is specified. Currently applies only to OAUTHBEARER.
-¦double
-¦0.8
-¦[0.5,...,1.0]
-¦low
+`sasl.login.refresh.window.factor`::
+*Type:* double +
+*Default:* 0.8 +
+*Valid Values:* [0.5,...,1.0] +
+*Importance:* low +
++
+Login refresh thread will sleep until the specified window factor relative to the credential's lifetime has been reached, at which time it will try to refresh the credential. Legal values are between 0.5 (50%) and 1.0 (100%) inclusive; a default value of 0.8 (80%) is used if no value is specified. Currently applies only to OAUTHBEARER.
 
-¦`sasl.login.refresh.window.jitter`
-a¦The maximum amount of random jitter relative to the credential's lifetime that is added to the login refresh thread's sleep time. Legal values are between 0 and 0.25 (25%) inclusive; a default value of 0.05 (5%) is used if no value is specified. Currently applies only to OAUTHBEARER.
-¦double
-¦0.05
-¦[0.0,...,0.25]
-¦low
+`sasl.login.refresh.window.jitter`::
+*Type:* double +
+*Default:* 0.05 +
+*Valid Values:* [0.0,...,0.25] +
+*Importance:* low +
++
+The maximum amount of random jitter relative to the credential's lifetime that is added to the login refresh thread's sleep time. Legal values are between 0 and 0.25 (25%) inclusive; a default value of 0.05 (5%) is used if no value is specified. Currently applies only to OAUTHBEARER.
 
-¦`ssl.cipher.suites`
-a¦A list of cipher suites. This is a named combination of authentication, encryption, MAC and key exchange algorithm used to negotiate the security settings for a network connection using TLS or SSL network protocol. By default all the available cipher suites are supported.
-¦list
-¦null
-¦
-¦low
+`ssl.cipher.suites`::
+*Type:* list +
+*Default:* null +
+*Importance:* low +
++
+A list of cipher suites. This is a named combination of authentication, encryption, MAC and key exchange algorithm used to negotiate the security settings for a network connection using TLS or SSL network protocol. By default all the available cipher suites are supported.
 
-¦`ssl.client.auth`
-a¦Configures kafka broker to request client authentication. The following settings are common:  
+`ssl.client.auth`::
+*Type:* string +
+*Default:* none +
+*Importance:* low +
++
+Configures kafka broker to request client authentication. The following settings are common:  
  
 * `ssl.client.auth=required` If set to required client authentication is required. 
 * `ssl.client.auth=requested` This means client authentication is optional. unlike requested , if this option is set client can choose not to provide authentication information about itself 
 * `ssl.client.auth=none` This means client authentication is not needed.
-¦string
-¦none
-¦
-¦low
 
-¦`ssl.endpoint.identification.algorithm`
-a¦The endpoint identification algorithm to validate server hostname using server certificate. 
-¦string
-¦https
-¦
-¦low
+`ssl.endpoint.identification.algorithm`::
+*Type:* string +
+*Default:* https +
+*Importance:* low +
++
+The endpoint identification algorithm to validate server hostname using server certificate.
 
-¦`ssl.keymanager.algorithm`
-a¦The algorithm used by key manager factory for SSL connections. Default value is the key manager factory algorithm configured for the Java Virtual Machine.
-¦string
-¦SunX509
-¦
-¦low
+`ssl.keymanager.algorithm`::
+*Type:* string +
+*Default:* SunX509 +
+*Importance:* low +
++
+The algorithm used by key manager factory for SSL connections. Default value is the key manager factory algorithm configured for the Java Virtual Machine.
 
-¦`ssl.secure.random.implementation`
-a¦The SecureRandom PRNG implementation to use for SSL cryptography operations. 
-¦string
-¦null
-¦
-¦low
+`ssl.secure.random.implementation`::
+*Type:* string +
+*Default:* null +
+*Importance:* low +
++
+The SecureRandom PRNG implementation to use for SSL cryptography operations.
 
-¦`ssl.trustmanager.algorithm`
-a¦The algorithm used by trust manager factory for SSL connections. Default value is the trust manager factory algorithm configured for the Java Virtual Machine.
-¦string
-¦PKIX
-¦
-¦low
+`ssl.trustmanager.algorithm`::
+*Type:* string +
+*Default:* PKIX +
+*Importance:* low +
++
+The algorithm used by trust manager factory for SSL connections. Default value is the trust manager factory algorithm configured for the Java Virtual Machine.
 
-¦`status.storage.partitions`
-a¦The number of partitions used when creating the status storage topic
-¦int
-¦5
-¦[1,...]
-¦low
+`status.storage.partitions`::
+*Type:* int +
+*Default:* 5 +
+*Valid Values:* [1,...] +
+*Importance:* low +
++
+The number of partitions used when creating the status storage topic.
 
-¦`status.storage.replication.factor`
-a¦Replication factor used when creating the status storage topic
-¦short
-¦3
-¦[1,...]
-¦low
+`status.storage.replication.factor`::
+*Type:* short +
+*Default:* 3 +
+*Valid Values:* [1,...] +
+*Importance:* low +
++
+Replication factor used when creating the status storage topic.
 
-¦`task.shutdown.graceful.timeout.ms`
-a¦Amount of time to wait for tasks to shutdown gracefully. This is the total amount of time, not per task. All task have shutdown triggered, then they are waited on sequentially.
-¦long
-¦5000
-¦
-¦low
-
-|=====
+`task.shutdown.graceful.timeout.ms`::
+*Type:* long +
+*Default:* 5000 +
+*Importance:* low +
++
+Amount of time to wait for tasks to shutdown gracefully. This is the total amount of time, not per task. All task have shutdown triggered, then they are waited on sequentially.

--- a/books/ref-consumer-config.adoc
+++ b/books/ref-consumer-config.adoc
@@ -1,470 +1,494 @@
 // Module included in the following assemblies:
 //
 // assembly-overview.adoc
+//
+// THIS FILE IS AUTO-GENERATED. DO NOT EDIT BY HAND
+// Run "make clean buildall" to regenerate.
 
 [id='consumer-configuration-parameters-{context}']
 = Consumer configuration parameters
 
-[cols="6",options="header",separator=¦]
-|=====
-¦Name ¦Description ¦Type ¦Default ¦Valid Values ¦Importance 
+`key.deserializer`::
+*Type:* class +
+*Importance:* high +
++
+Deserializer class for key that implements the `org.apache.kafka.common.serialization.Deserializer` interface.
 
-¦`key.deserializer`
-a¦Deserializer class for key that implements the `org.apache.kafka.common.serialization.Deserializer` interface.
-¦class
-¦
-¦
-¦high
+`value.deserializer`::
+*Type:* class +
+*Importance:* high +
++
+Deserializer class for value that implements the `org.apache.kafka.common.serialization.Deserializer` interface.
 
-¦`value.deserializer`
-a¦Deserializer class for value that implements the `org.apache.kafka.common.serialization.Deserializer` interface.
-¦class
-¦
-¦
-¦high
+`bootstrap.servers`::
+*Type:* list +
+*Default:* "" +
+*Valid Values:* non-null value +
+*Importance:* high +
++
+A list of host/port pairs to use for establishing the initial connection to the Kafka cluster. The client will make use of all servers irrespective of which servers are specified here for bootstrapping&mdash;this list only impacts the initial hosts used to discover the full set of servers. This list should be in the form `host1:port1,host2:port2,...`. Since these servers are just used for the initial connection to discover the full cluster membership (which may change dynamically), this list need not contain the full set of servers (you may want more than one, though, in case a server is down).
 
-¦`bootstrap.servers`
-a¦A list of host/port pairs to use for establishing the initial connection to the Kafka cluster. The client will make use of all servers irrespective of which servers are specified here for bootstrapping&mdash;this list only impacts the initial hosts used to discover the full set of servers. This list should be in the form `host1:port1,host2:port2,...`. Since these servers are just used for the initial connection to discover the full cluster membership (which may change dynamically), this list need not contain the full set of servers (you may want more than one, though, in case a server is down).
-¦list
-¦""
-¦non-null value
-¦high
+`fetch.min.bytes`::
+*Type:* int +
+*Default:* 1 +
+*Valid Values:* [0,...] +
+*Importance:* high +
++
+The minimum amount of data the server should return for a fetch request. If insufficient data is available the request will wait for that much data to accumulate before answering the request. The default setting of 1 byte means that fetch requests are answered as soon as a single byte of data is available or the fetch request times out waiting for data to arrive. Setting this to something greater than 1 will cause the server to wait for larger amounts of data to accumulate which can improve server throughput a bit at the cost of some additional latency.
 
-¦`fetch.min.bytes`
-a¦The minimum amount of data the server should return for a fetch request. If insufficient data is available the request will wait for that much data to accumulate before answering the request. The default setting of 1 byte means that fetch requests are answered as soon as a single byte of data is available or the fetch request times out waiting for data to arrive. Setting this to something greater than 1 will cause the server to wait for larger amounts of data to accumulate which can improve server throughput a bit at the cost of some additional latency.
-¦int
-¦1
-¦[0,...]
-¦high
+`group.id`::
+*Type:* string +
+*Default:* "" +
+*Importance:* high +
++
+A unique string that identifies the consumer group this consumer belongs to. This property is required if the consumer uses either the group management functionality by using `subscribe(topic)` or the Kafka-based offset management strategy.
 
-¦`group.id`
-a¦A unique string that identifies the consumer group this consumer belongs to. This property is required if the consumer uses either the group management functionality by using `subscribe(topic)` or the Kafka-based offset management strategy.
-¦string
-¦""
-¦
-¦high
+`heartbeat.interval.ms`::
+*Type:* int +
+*Default:* 3000 +
+*Importance:* high +
++
+The expected time between heartbeats to the consumer coordinator when using Kafka's group management facilities. Heartbeats are used to ensure that the consumer's session stays active and to facilitate rebalancing when new consumers join or leave the group. The value must be set lower than `session.timeout.ms`, but typically should be set no higher than 1/3 of that value. It can be adjusted even lower to control the expected time for normal rebalances.
 
-¦`heartbeat.interval.ms`
-a¦The expected time between heartbeats to the consumer coordinator when using Kafka's group management facilities. Heartbeats are used to ensure that the consumer's session stays active and to facilitate rebalancing when new consumers join or leave the group. The value must be set lower than `session.timeout.ms`, but typically should be set no higher than 1/3 of that value. It can be adjusted even lower to control the expected time for normal rebalances.
-¦int
-¦3000
-¦
-¦high
+`max.partition.fetch.bytes`::
+*Type:* int +
+*Default:* 1048576 +
+*Valid Values:* [0,...] +
+*Importance:* high +
++
+The maximum amount of data per-partition the server will return. Records are fetched in batches by the consumer. If the first record batch in the first non-empty partition of the fetch is larger than this limit, the batch will still be returned to ensure that the consumer can make progress. The maximum record batch size accepted by the broker is defined via `message.max.bytes` (broker config) or `max.message.bytes` (topic config). See fetch.max.bytes for limiting the consumer request size.
 
-¦`max.partition.fetch.bytes`
-a¦The maximum amount of data per-partition the server will return. Records are fetched in batches by the consumer. If the first record batch in the first non-empty partition of the fetch is larger than this limit, the batch will still be returned to ensure that the consumer can make progress. The maximum record batch size accepted by the broker is defined via `message.max.bytes` (broker config) or `max.message.bytes` (topic config). See fetch.max.bytes for limiting the consumer request size.
-¦int
-¦1048576
-¦[0,...]
-¦high
+`session.timeout.ms`::
+*Type:* int +
+*Default:* 10000 +
+*Importance:* high +
++
+The timeout used to detect consumer failures when using Kafka's group management facility. The consumer sends periodic heartbeats to indicate its liveness to the broker. If no heartbeats are received by the broker before the expiration of this session timeout, then the broker will remove this consumer from the group and initiate a rebalance. Note that the value must be in the allowable range as configured in the broker configuration by `group.min.session.timeout.ms` and `group.max.session.timeout.ms`.
 
-¦`session.timeout.ms`
-a¦The timeout used to detect consumer failures when using Kafka's group management facility. The consumer sends periodic heartbeats to indicate its liveness to the broker. If no heartbeats are received by the broker before the expiration of this session timeout, then the broker will remove this consumer from the group and initiate a rebalance. Note that the value must be in the allowable range as configured in the broker configuration by `group.min.session.timeout.ms` and `group.max.session.timeout.ms`.
-¦int
-¦10000
-¦
-¦high
+`ssl.key.password`::
+*Type:* password +
+*Default:* null +
+*Importance:* high +
++
+The password of the private key in the key store file. This is optional for client.
 
-¦`ssl.key.password`
-a¦The password of the private key in the key store file. This is optional for client.
-¦password
-¦null
-¦
-¦high
+`ssl.keystore.location`::
+*Type:* string +
+*Default:* null +
+*Importance:* high +
++
+The location of the key store file. This is optional for client and can be used for two-way authentication for client.
 
-¦`ssl.keystore.location`
-a¦The location of the key store file. This is optional for client and can be used for two-way authentication for client.
-¦string
-¦null
-¦
-¦high
+`ssl.keystore.password`::
+*Type:* password +
+*Default:* null +
+*Importance:* high +
++
+The store password for the key store file. This is optional for client and only needed if ssl.keystore.location is configured.
 
-¦`ssl.keystore.password`
-a¦The store password for the key store file. This is optional for client and only needed if ssl.keystore.location is configured. 
-¦password
-¦null
-¦
-¦high
+`ssl.truststore.location`::
+*Type:* string +
+*Default:* null +
+*Importance:* high +
++
+The location of the trust store file.
 
-¦`ssl.truststore.location`
-a¦The location of the trust store file. 
-¦string
-¦null
-¦
-¦high
+`ssl.truststore.password`::
+*Type:* password +
+*Default:* null +
+*Importance:* high +
++
+The password for the trust store file. If a password is not set access to the truststore is still available, but integrity checking is disabled.
 
-¦`ssl.truststore.password`
-a¦The password for the trust store file. If a password is not set access to the truststore is still available, but integrity checking is disabled.
-¦password
-¦null
-¦
-¦high
-
-¦`auto.offset.reset`
-a¦What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server (e.g. because that data has been deleted): 
+`auto.offset.reset`::
+*Type:* string +
+*Default:* latest +
+*Valid Values:* [latest, earliest, none] +
+*Importance:* medium +
++
+What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server (e.g. because that data has been deleted): 
 
 * earliest: automatically reset the offset to the earliest offset
 * latest: automatically reset the offset to the latest offset
 * none: throw exception to the consumer if no previous offset is found for the consumer's group
 * anything else: throw exception to the consumer.
-¦string
-¦latest
-¦[latest, earliest, none]
-¦medium
 
-¦`connections.max.idle.ms`
-a¦Close idle connections after the number of milliseconds specified by this config.
-¦long
-¦540000
-¦
-¦medium
+`connections.max.idle.ms`::
+*Type:* long +
+*Default:* 540000 +
+*Importance:* medium +
++
+Close idle connections after the number of milliseconds specified by this config.
 
-¦`default.api.timeout.ms`
-a¦Specifies the timeout (in milliseconds) for consumer APIs that could block. This configuration is used as the default timeout for all consumer operations that do not explicitly accept a `timeout` parameter.
-¦int
-¦60000
-¦[0,...]
-¦medium
+`default.api.timeout.ms`::
+*Type:* int +
+*Default:* 60000 +
+*Valid Values:* [0,...] +
+*Importance:* medium +
++
+Specifies the timeout (in milliseconds) for consumer APIs that could block. This configuration is used as the default timeout for all consumer operations that do not explicitly accept a `timeout` parameter.
 
-¦`enable.auto.commit`
-a¦If true the consumer's offset will be periodically committed in the background.
-¦boolean
-¦true
-¦
-¦medium
+`enable.auto.commit`::
+*Type:* boolean +
+*Default:* true +
+*Importance:* medium +
++
+If true the consumer's offset will be periodically committed in the background.
 
-¦`exclude.internal.topics`
-a¦Whether records from internal topics (such as offsets) should be exposed to the consumer. If set to `true` the only way to receive records from an internal topic is subscribing to it.
-¦boolean
-¦true
-¦
-¦medium
+`exclude.internal.topics`::
+*Type:* boolean +
+*Default:* true +
+*Importance:* medium +
++
+Whether records from internal topics (such as offsets) should be exposed to the consumer. If set to `true` the only way to receive records from an internal topic is subscribing to it.
 
-¦`fetch.max.bytes`
-a¦The maximum amount of data the server should return for a fetch request. Records are fetched in batches by the consumer, and if the first record batch in the first non-empty partition of the fetch is larger than this value, the record batch will still be returned to ensure that the consumer can make progress. As such, this is not a absolute maximum. The maximum record batch size accepted by the broker is defined via `message.max.bytes` (broker config) or `max.message.bytes` (topic config). Note that the consumer performs multiple fetches in parallel.
-¦int
-¦52428800
-¦[0,...]
-¦medium
+`fetch.max.bytes`::
+*Type:* int +
+*Default:* 52428800 +
+*Valid Values:* [0,...] +
+*Importance:* medium +
++
+The maximum amount of data the server should return for a fetch request. Records are fetched in batches by the consumer, and if the first record batch in the first non-empty partition of the fetch is larger than this value, the record batch will still be returned to ensure that the consumer can make progress. As such, this is not a absolute maximum. The maximum record batch size accepted by the broker is defined via `message.max.bytes` (broker config) or `max.message.bytes` (topic config). Note that the consumer performs multiple fetches in parallel.
 
-¦`isolation.level`
-a¦
+`isolation.level`::
+*Type:* string +
+*Default:* read_uncommitted +
+*Valid Values:* [read_committed, read_uncommitted] +
+*Importance:* medium +
++
+
++
 Controls how to read messages written transactionally. If set to `read_committed`, consumer.poll() will only return transactional messages which have been committed. If set to `read_uncommitted`' (the default), consumer.poll() will return all messages, even transactional messages which have been aborted. Non-transactional messages will be returned unconditionally in either mode.
- 
++
 Messages will always be returned in offset order. Hence, in  `read_committed` mode, consumer.poll() will only return messages up to the last stable offset (LSO), which is the one less than the offset of the first open transaction. In particular any messages appearing after messages belonging to ongoing transactions will be withheld until the relevant transaction has been completed. As a result, `read_committed` consumers will not be able to read up to the high watermark when there are in flight transactions.
++
+ Further, when in `read_committed</mode> the seekToEnd method will return the LSO.
 
- Further, when in `read_committed</mode> the seekToEnd method will return the LSO
-¦string
-¦read_uncommitted
-¦[read_committed, read_uncommitted]
-¦medium
+`max.poll.interval.ms`::
+*Type:* int +
+*Default:* 300000 +
+*Valid Values:* [1,...] +
+*Importance:* medium +
++
+The maximum delay between invocations of poll() when using consumer group management. This places an upper bound on the amount of time that the consumer can be idle before fetching more records. If poll() is not called before expiration of this timeout, then the consumer is considered failed and the group will rebalance in order to reassign the partitions to another member.
 
-¦`max.poll.interval.ms`
-a¦The maximum delay between invocations of poll() when using consumer group management. This places an upper bound on the amount of time that the consumer can be idle before fetching more records. If poll() is not called before expiration of this timeout, then the consumer is considered failed and the group will rebalance in order to reassign the partitions to another member. 
-¦int
-¦300000
-¦[1,...]
-¦medium
+`max.poll.records`::
+*Type:* int +
+*Default:* 500 +
+*Valid Values:* [1,...] +
+*Importance:* medium +
++
+The maximum number of records returned in a single call to poll().
 
-¦`max.poll.records`
-a¦The maximum number of records returned in a single call to poll().
-¦int
-¦500
-¦[1,...]
-¦medium
+`partition.assignment.strategy`::
+*Type:* list +
+*Default:* class org.apache.kafka.clients.consumer.RangeAssignor +
+*Valid Values:* non-null value +
+*Importance:* medium +
++
+The class name of the partition assignment strategy that the client will use to distribute partition ownership amongst consumer instances when group management is used.
 
-¦`partition.assignment.strategy`
-a¦The class name of the partition assignment strategy that the client will use to distribute partition ownership amongst consumer instances when group management is used
-¦list
-¦class org.apache.kafka.clients.consumer.RangeAssignor
-¦non-null value
-¦medium
+`receive.buffer.bytes`::
+*Type:* int +
+*Default:* 65536 +
+*Valid Values:* [-1,...] +
+*Importance:* medium +
++
+The size of the TCP receive buffer (SO_RCVBUF) to use when reading data. If the value is -1, the OS default will be used.
 
-¦`receive.buffer.bytes`
-a¦The size of the TCP receive buffer (SO_RCVBUF) to use when reading data. If the value is -1, the OS default will be used.
-¦int
-¦65536
-¦[-1,...]
-¦medium
+`request.timeout.ms`::
+*Type:* int +
+*Default:* 30000 +
+*Valid Values:* [0,...] +
+*Importance:* medium +
++
+The configuration controls the maximum amount of time the client will wait for the response of a request. If the response is not received before the timeout elapses the client will resend the request if necessary or fail the request if retries are exhausted.
 
-¦`request.timeout.ms`
-a¦The configuration controls the maximum amount of time the client will wait for the response of a request. If the response is not received before the timeout elapses the client will resend the request if necessary or fail the request if retries are exhausted.
-¦int
-¦30000
-¦[0,...]
-¦medium
+`sasl.client.callback.handler.class`::
+*Type:* class +
+*Default:* null +
+*Importance:* medium +
++
+The fully qualified name of a SASL client callback handler class that implements the AuthenticateCallbackHandler interface.
 
-¦`sasl.client.callback.handler.class`
-a¦The fully qualified name of a SASL client callback handler class that implements the AuthenticateCallbackHandler interface.
-¦class
-¦null
-¦
-¦medium
+`sasl.jaas.config`::
+*Type:* password +
+*Default:* null +
+*Importance:* medium +
++
+JAAS login context parameters for SASL connections in the format used by JAAS configuration files. JAAS configuration file format is described http://docs.oracle.com/javase/8/docs/technotes/guides/security/jgss/tutorials/LoginConfigFile.html[here]. The format for the value is: '`loginModuleClass controlFlag (optionName=optionValue)*;`'. For brokers, the config must be prefixed with listener prefix and SASL mechanism name in lower-case. For example, listener.name.sasl_ssl.scram-sha-256.sasl.jaas.config=com.example.ScramLoginModule required;.
 
-¦`sasl.jaas.config`
-a¦JAAS login context parameters for SASL connections in the format used by JAAS configuration files. JAAS configuration file format is described http://docs.oracle.com/javase/8/docs/technotes/guides/security/jgss/tutorials/LoginConfigFile.html[here]. The format for the value is: '`loginModuleClass controlFlag (optionName=optionValue)*;`'. For brokers, the config must be prefixed with listener prefix and SASL mechanism name in lower-case. For example, listener.name.sasl_ssl.scram-sha-256.sasl.jaas.config=com.example.ScramLoginModule required;
-¦password
-¦null
-¦
-¦medium
+`sasl.kerberos.service.name`::
+*Type:* string +
+*Default:* null +
+*Importance:* medium +
++
+The Kerberos principal name that Kafka runs as. This can be defined either in Kafka's JAAS config or in Kafka's config.
 
-¦`sasl.kerberos.service.name`
-a¦The Kerberos principal name that Kafka runs as. This can be defined either in Kafka's JAAS config or in Kafka's config.
-¦string
-¦null
-¦
-¦medium
+`sasl.login.callback.handler.class`::
+*Type:* class +
+*Default:* null +
+*Importance:* medium +
++
+The fully qualified name of a SASL login callback handler class that implements the AuthenticateCallbackHandler interface. For brokers, login callback handler config must be prefixed with listener prefix and SASL mechanism name in lower-case. For example, listener.name.sasl_ssl.scram-sha-256.sasl.login.callback.handler.class=com.example.CustomScramLoginCallbackHandler.
 
-¦`sasl.login.callback.handler.class`
-a¦The fully qualified name of a SASL login callback handler class that implements the AuthenticateCallbackHandler interface. For brokers, login callback handler config must be prefixed with listener prefix and SASL mechanism name in lower-case. For example, listener.name.sasl_ssl.scram-sha-256.sasl.login.callback.handler.class=com.example.CustomScramLoginCallbackHandler
-¦class
-¦null
-¦
-¦medium
+`sasl.login.class`::
+*Type:* class +
+*Default:* null +
+*Importance:* medium +
++
+The fully qualified name of a class that implements the Login interface. For brokers, login config must be prefixed with listener prefix and SASL mechanism name in lower-case. For example, listener.name.sasl_ssl.scram-sha-256.sasl.login.class=com.example.CustomScramLogin.
 
-¦`sasl.login.class`
-a¦The fully qualified name of a class that implements the Login interface. For brokers, login config must be prefixed with listener prefix and SASL mechanism name in lower-case. For example, listener.name.sasl_ssl.scram-sha-256.sasl.login.class=com.example.CustomScramLogin
-¦class
-¦null
-¦
-¦medium
+`sasl.mechanism`::
+*Type:* string +
+*Default:* GSSAPI +
+*Importance:* medium +
++
+SASL mechanism used for client connections. This may be any mechanism for which a security provider is available. GSSAPI is the default mechanism.
 
-¦`sasl.mechanism`
-a¦SASL mechanism used for client connections. This may be any mechanism for which a security provider is available. GSSAPI is the default mechanism.
-¦string
-¦GSSAPI
-¦
-¦medium
+`security.protocol`::
+*Type:* string +
+*Default:* PLAINTEXT +
+*Importance:* medium +
++
+Protocol used to communicate with brokers. Valid values are: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL.
 
-¦`security.protocol`
-a¦Protocol used to communicate with brokers. Valid values are: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL.
-¦string
-¦PLAINTEXT
-¦
-¦medium
+`send.buffer.bytes`::
+*Type:* int +
+*Default:* 131072 +
+*Valid Values:* [-1,...] +
+*Importance:* medium +
++
+The size of the TCP send buffer (SO_SNDBUF) to use when sending data. If the value is -1, the OS default will be used.
 
-¦`send.buffer.bytes`
-a¦The size of the TCP send buffer (SO_SNDBUF) to use when sending data. If the value is -1, the OS default will be used.
-¦int
-¦131072
-¦[-1,...]
-¦medium
+`ssl.enabled.protocols`::
+*Type:* list +
+*Default:* TLSv1.2,TLSv1.1,TLSv1 +
+*Importance:* medium +
++
+The list of protocols enabled for SSL connections.
 
-¦`ssl.enabled.protocols`
-a¦The list of protocols enabled for SSL connections.
-¦list
-¦TLSv1.2,TLSv1.1,TLSv1
-¦
-¦medium
+`ssl.keystore.type`::
+*Type:* string +
+*Default:* JKS +
+*Importance:* medium +
++
+The file format of the key store file. This is optional for client.
 
-¦`ssl.keystore.type`
-a¦The file format of the key store file. This is optional for client.
-¦string
-¦JKS
-¦
-¦medium
+`ssl.protocol`::
+*Type:* string +
+*Default:* TLS +
+*Importance:* medium +
++
+The SSL protocol used to generate the SSLContext. Default setting is TLS, which is fine for most cases. Allowed values in recent JVMs are TLS, TLSv1.1 and TLSv1.2. SSL, SSLv2 and SSLv3 may be supported in older JVMs, but their usage is discouraged due to known security vulnerabilities.
 
-¦`ssl.protocol`
-a¦The SSL protocol used to generate the SSLContext. Default setting is TLS, which is fine for most cases. Allowed values in recent JVMs are TLS, TLSv1.1 and TLSv1.2. SSL, SSLv2 and SSLv3 may be supported in older JVMs, but their usage is discouraged due to known security vulnerabilities.
-¦string
-¦TLS
-¦
-¦medium
+`ssl.provider`::
+*Type:* string +
+*Default:* null +
+*Importance:* medium +
++
+The name of the security provider used for SSL connections. Default value is the default security provider of the JVM.
 
-¦`ssl.provider`
-a¦The name of the security provider used for SSL connections. Default value is the default security provider of the JVM.
-¦string
-¦null
-¦
-¦medium
+`ssl.truststore.type`::
+*Type:* string +
+*Default:* JKS +
+*Importance:* medium +
++
+The file format of the trust store file.
 
-¦`ssl.truststore.type`
-a¦The file format of the trust store file.
-¦string
-¦JKS
-¦
-¦medium
+`auto.commit.interval.ms`::
+*Type:* int +
+*Default:* 5000 +
+*Valid Values:* [0,...] +
+*Importance:* low +
++
+The frequency in milliseconds that the consumer offsets are auto-committed to Kafka if `enable.auto.commit` is set to `true`.
 
-¦`auto.commit.interval.ms`
-a¦The frequency in milliseconds that the consumer offsets are auto-committed to Kafka if `enable.auto.commit` is set to `true`.
-¦int
-¦5000
-¦[0,...]
-¦low
+`check.crcs`::
+*Type:* boolean +
+*Default:* true +
+*Importance:* low +
++
+Automatically check the CRC32 of the records consumed. This ensures no on-the-wire or on-disk corruption to the messages occurred. This check adds some overhead, so it may be disabled in cases seeking extreme performance.
 
-¦`check.crcs`
-a¦Automatically check the CRC32 of the records consumed. This ensures no on-the-wire or on-disk corruption to the messages occurred. This check adds some overhead, so it may be disabled in cases seeking extreme performance.
-¦boolean
-¦true
-¦
-¦low
+`client.id`::
+*Type:* string +
+*Default:* "" +
+*Importance:* low +
++
+An id string to pass to the server when making requests. The purpose of this is to be able to track the source of requests beyond just ip/port by allowing a logical application name to be included in server-side request logging.
 
-¦`client.id`
-a¦An id string to pass to the server when making requests. The purpose of this is to be able to track the source of requests beyond just ip/port by allowing a logical application name to be included in server-side request logging.
-¦string
-¦""
-¦
-¦low
+`fetch.max.wait.ms`::
+*Type:* int +
+*Default:* 500 +
+*Valid Values:* [0,...] +
+*Importance:* low +
++
+The maximum amount of time the server will block before answering the fetch request if there isn't sufficient data to immediately satisfy the requirement given by fetch.min.bytes.
 
-¦`fetch.max.wait.ms`
-a¦The maximum amount of time the server will block before answering the fetch request if there isn't sufficient data to immediately satisfy the requirement given by fetch.min.bytes.
-¦int
-¦500
-¦[0,...]
-¦low
+`interceptor.classes`::
+*Type:* list +
+*Default:* "" +
+*Valid Values:* non-null value +
+*Importance:* low +
++
+A list of classes to use as interceptors. Implementing the `org.apache.kafka.clients.consumer.ConsumerInterceptor` interface allows you to intercept (and possibly mutate) records received by the consumer. By default, there are no interceptors.
 
-¦`interceptor.classes`
-a¦A list of classes to use as interceptors. Implementing the `org.apache.kafka.clients.consumer.ConsumerInterceptor` interface allows you to intercept (and possibly mutate) records received by the consumer. By default, there are no interceptors.
-¦list
-¦""
-¦non-null value
-¦low
+`metadata.max.age.ms`::
+*Type:* long +
+*Default:* 300000 +
+*Valid Values:* [0,...] +
+*Importance:* low +
++
+The period of time in milliseconds after which we force a refresh of metadata even if we haven't seen any partition leadership changes to proactively discover any new brokers or partitions.
 
-¦`metadata.max.age.ms`
-a¦The period of time in milliseconds after which we force a refresh of metadata even if we haven't seen any partition leadership changes to proactively discover any new brokers or partitions.
-¦long
-¦300000
-¦[0,...]
-¦low
+`metric.reporters`::
+*Type:* list +
+*Default:* "" +
+*Valid Values:* non-null value +
+*Importance:* low +
++
+A list of classes to use as metrics reporters. Implementing the `org.apache.kafka.common.metrics.MetricsReporter` interface allows plugging in classes that will be notified of new metric creation. The JmxReporter is always included to register JMX statistics.
 
-¦`metric.reporters`
-a¦A list of classes to use as metrics reporters. Implementing the `org.apache.kafka.common.metrics.MetricsReporter` interface allows plugging in classes that will be notified of new metric creation. The JmxReporter is always included to register JMX statistics.
-¦list
-¦""
-¦non-null value
-¦low
+`metrics.num.samples`::
+*Type:* int +
+*Default:* 2 +
+*Valid Values:* [1,...] +
+*Importance:* low +
++
+The number of samples maintained to compute metrics.
 
-¦`metrics.num.samples`
-a¦The number of samples maintained to compute metrics.
-¦int
-¦2
-¦[1,...]
-¦low
+`metrics.recording.level`::
+*Type:* string +
+*Default:* INFO +
+*Valid Values:* [INFO, DEBUG] +
+*Importance:* low +
++
+The highest recording level for metrics.
 
-¦`metrics.recording.level`
-a¦The highest recording level for metrics.
-¦string
-¦INFO
-¦[INFO, DEBUG]
-¦low
+`metrics.sample.window.ms`::
+*Type:* long +
+*Default:* 30000 +
+*Valid Values:* [0,...] +
+*Importance:* low +
++
+The window of time a metrics sample is computed over.
 
-¦`metrics.sample.window.ms`
-a¦The window of time a metrics sample is computed over.
-¦long
-¦30000
-¦[0,...]
-¦low
+`reconnect.backoff.max.ms`::
+*Type:* long +
+*Default:* 1000 +
+*Valid Values:* [0,...] +
+*Importance:* low +
++
+The maximum amount of time in milliseconds to wait when reconnecting to a broker that has repeatedly failed to connect. If provided, the backoff per host will increase exponentially for each consecutive connection failure, up to this maximum. After calculating the backoff increase, 20% random jitter is added to avoid connection storms.
 
-¦`reconnect.backoff.max.ms`
-a¦The maximum amount of time in milliseconds to wait when reconnecting to a broker that has repeatedly failed to connect. If provided, the backoff per host will increase exponentially for each consecutive connection failure, up to this maximum. After calculating the backoff increase, 20% random jitter is added to avoid connection storms.
-¦long
-¦1000
-¦[0,...]
-¦low
+`reconnect.backoff.ms`::
+*Type:* long +
+*Default:* 50 +
+*Valid Values:* [0,...] +
+*Importance:* low +
++
+The base amount of time to wait before attempting to reconnect to a given host. This avoids repeatedly connecting to a host in a tight loop. This backoff applies to all connection attempts by the client to a broker.
 
-¦`reconnect.backoff.ms`
-a¦The base amount of time to wait before attempting to reconnect to a given host. This avoids repeatedly connecting to a host in a tight loop. This backoff applies to all connection attempts by the client to a broker.
-¦long
-¦50
-¦[0,...]
-¦low
+`retry.backoff.ms`::
+*Type:* long +
+*Default:* 100 +
+*Valid Values:* [0,...] +
+*Importance:* low +
++
+The amount of time to wait before attempting to retry a failed request to a given topic partition. This avoids repeatedly sending requests in a tight loop under some failure scenarios.
 
-¦`retry.backoff.ms`
-a¦The amount of time to wait before attempting to retry a failed request to a given topic partition. This avoids repeatedly sending requests in a tight loop under some failure scenarios.
-¦long
-¦100
-¦[0,...]
-¦low
+`sasl.kerberos.kinit.cmd`::
+*Type:* string +
+*Default:* /usr/bin/kinit +
+*Importance:* low +
++
+Kerberos kinit command path.
 
-¦`sasl.kerberos.kinit.cmd`
-a¦Kerberos kinit command path.
-¦string
-¦/usr/bin/kinit
-¦
-¦low
+`sasl.kerberos.min.time.before.relogin`::
+*Type:* long +
+*Default:* 60000 +
+*Importance:* low +
++
+Login thread sleep time between refresh attempts.
 
-¦`sasl.kerberos.min.time.before.relogin`
-a¦Login thread sleep time between refresh attempts.
-¦long
-¦60000
-¦
-¦low
+`sasl.kerberos.ticket.renew.jitter`::
+*Type:* double +
+*Default:* 0.05 +
+*Importance:* low +
++
+Percentage of random jitter added to the renewal time.
 
-¦`sasl.kerberos.ticket.renew.jitter`
-a¦Percentage of random jitter added to the renewal time.
-¦double
-¦0.05
-¦
-¦low
+`sasl.kerberos.ticket.renew.window.factor`::
+*Type:* double +
+*Default:* 0.8 +
+*Importance:* low +
++
+Login thread will sleep until the specified window factor of time from last refresh to ticket's expiry has been reached, at which time it will try to renew the ticket.
 
-¦`sasl.kerberos.ticket.renew.window.factor`
-a¦Login thread will sleep until the specified window factor of time from last refresh to ticket's expiry has been reached, at which time it will try to renew the ticket.
-¦double
-¦0.8
-¦
-¦low
+`sasl.login.refresh.buffer.seconds`::
+*Type:* short +
+*Default:* 300 +
+*Valid Values:* [0,...,3600] +
+*Importance:* low +
++
+The amount of buffer time before credential expiration to maintain when refreshing a credential, in seconds. If a refresh would otherwise occur closer to expiration than the number of buffer seconds then the refresh will be moved up to maintain as much of the buffer time as possible. Legal values are between 0 and 3600 (1 hour); a default value of  300 (5 minutes) is used if no value is specified. This value and sasl.login.refresh.min.period.seconds are both ignored if their sum exceeds the remaining lifetime of a credential. Currently applies only to OAUTHBEARER.
 
-¦`sasl.login.refresh.buffer.seconds`
-a¦The amount of buffer time before credential expiration to maintain when refreshing a credential, in seconds. If a refresh would otherwise occur closer to expiration than the number of buffer seconds then the refresh will be moved up to maintain as much of the buffer time as possible. Legal values are between 0 and 3600 (1 hour); a default value of  300 (5 minutes) is used if no value is specified. This value and sasl.login.refresh.min.period.seconds are both ignored if their sum exceeds the remaining lifetime of a credential. Currently applies only to OAUTHBEARER.
-¦short
-¦300
-¦[0,...,3600]
-¦low
+`sasl.login.refresh.min.period.seconds`::
+*Type:* short +
+*Default:* 60 +
+*Valid Values:* [0,...,900] +
+*Importance:* low +
++
+The desired minimum time for the login refresh thread to wait before refreshing a credential, in seconds. Legal values are between 0 and 900 (15 minutes); a default value of 60 (1 minute) is used if no value is specified.  This value and  sasl.login.refresh.buffer.seconds are both ignored if their sum exceeds the remaining lifetime of a credential. Currently applies only to OAUTHBEARER.
 
-¦`sasl.login.refresh.min.period.seconds`
-a¦The desired minimum time for the login refresh thread to wait before refreshing a credential, in seconds. Legal values are between 0 and 900 (15 minutes); a default value of 60 (1 minute) is used if no value is specified.  This value and  sasl.login.refresh.buffer.seconds are both ignored if their sum exceeds the remaining lifetime of a credential. Currently applies only to OAUTHBEARER.
-¦short
-¦60
-¦[0,...,900]
-¦low
+`sasl.login.refresh.window.factor`::
+*Type:* double +
+*Default:* 0.8 +
+*Valid Values:* [0.5,...,1.0] +
+*Importance:* low +
++
+Login refresh thread will sleep until the specified window factor relative to the credential's lifetime has been reached, at which time it will try to refresh the credential. Legal values are between 0.5 (50%) and 1.0 (100%) inclusive; a default value of 0.8 (80%) is used if no value is specified. Currently applies only to OAUTHBEARER.
 
-¦`sasl.login.refresh.window.factor`
-a¦Login refresh thread will sleep until the specified window factor relative to the credential's lifetime has been reached, at which time it will try to refresh the credential. Legal values are between 0.5 (50%) and 1.0 (100%) inclusive; a default value of 0.8 (80%) is used if no value is specified. Currently applies only to OAUTHBEARER.
-¦double
-¦0.8
-¦[0.5,...,1.0]
-¦low
+`sasl.login.refresh.window.jitter`::
+*Type:* double +
+*Default:* 0.05 +
+*Valid Values:* [0.0,...,0.25] +
+*Importance:* low +
++
+The maximum amount of random jitter relative to the credential's lifetime that is added to the login refresh thread's sleep time. Legal values are between 0 and 0.25 (25%) inclusive; a default value of 0.05 (5%) is used if no value is specified. Currently applies only to OAUTHBEARER.
 
-¦`sasl.login.refresh.window.jitter`
-a¦The maximum amount of random jitter relative to the credential's lifetime that is added to the login refresh thread's sleep time. Legal values are between 0 and 0.25 (25%) inclusive; a default value of 0.05 (5%) is used if no value is specified. Currently applies only to OAUTHBEARER.
-¦double
-¦0.05
-¦[0.0,...,0.25]
-¦low
+`ssl.cipher.suites`::
+*Type:* list +
+*Default:* null +
+*Importance:* low +
++
+A list of cipher suites. This is a named combination of authentication, encryption, MAC and key exchange algorithm used to negotiate the security settings for a network connection using TLS or SSL network protocol. By default all the available cipher suites are supported.
 
-¦`ssl.cipher.suites`
-a¦A list of cipher suites. This is a named combination of authentication, encryption, MAC and key exchange algorithm used to negotiate the security settings for a network connection using TLS or SSL network protocol. By default all the available cipher suites are supported.
-¦list
-¦null
-¦
-¦low
+`ssl.endpoint.identification.algorithm`::
+*Type:* string +
+*Default:* https +
+*Importance:* low +
++
+The endpoint identification algorithm to validate server hostname using server certificate.
 
-¦`ssl.endpoint.identification.algorithm`
-a¦The endpoint identification algorithm to validate server hostname using server certificate. 
-¦string
-¦https
-¦
-¦low
+`ssl.keymanager.algorithm`::
+*Type:* string +
+*Default:* SunX509 +
+*Importance:* low +
++
+The algorithm used by key manager factory for SSL connections. Default value is the key manager factory algorithm configured for the Java Virtual Machine.
 
-¦`ssl.keymanager.algorithm`
-a¦The algorithm used by key manager factory for SSL connections. Default value is the key manager factory algorithm configured for the Java Virtual Machine.
-¦string
-¦SunX509
-¦
-¦low
+`ssl.secure.random.implementation`::
+*Type:* string +
+*Default:* null +
+*Importance:* low +
++
+The SecureRandom PRNG implementation to use for SSL cryptography operations.
 
-¦`ssl.secure.random.implementation`
-a¦The SecureRandom PRNG implementation to use for SSL cryptography operations. 
-¦string
-¦null
-¦
-¦low
-
-¦`ssl.trustmanager.algorithm`
-a¦The algorithm used by trust manager factory for SSL connections. Default value is the trust manager factory algorithm configured for the Java Virtual Machine.
-¦string
-¦PKIX
-¦
-¦low
-
-|=====
+`ssl.trustmanager.algorithm`::
+*Type:* string +
+*Default:* PKIX +
+*Importance:* low +
++
+The algorithm used by trust manager factory for SSL connections. Default value is the trust manager factory algorithm configured for the Java Virtual Machine.

--- a/books/ref-producer-config.adoc
+++ b/books/ref-producer-config.adoc
@@ -1,440 +1,465 @@
 // Module included in the following assemblies:
 //
 // assembly-overview.adoc
+//
+// THIS FILE IS AUTO-GENERATED. DO NOT EDIT BY HAND
+// Run "make clean buildall" to regenerate.
 
 [id='producer-configuration-parameters-{context}']
 = Producer configuration parameters
 
-[cols="6",options="header",separator=¦]
-|=====
-¦Name ¦Description ¦Type ¦Default ¦Valid Values ¦Importance 
+`key.serializer`::
+*Type:* class +
+*Importance:* high +
++
+Serializer class for key that implements the `org.apache.kafka.common.serialization.Serializer` interface.
 
-¦`key.serializer`
-a¦Serializer class for key that implements the `org.apache.kafka.common.serialization.Serializer` interface.
-¦class
-¦
-¦
-¦high
+`value.serializer`::
+*Type:* class +
+*Importance:* high +
++
+Serializer class for value that implements the `org.apache.kafka.common.serialization.Serializer` interface.
 
-¦`value.serializer`
-a¦Serializer class for value that implements the `org.apache.kafka.common.serialization.Serializer` interface.
-¦class
-¦
-¦
-¦high
-
-¦`acks`
-a¦The number of acknowledgments the producer requires the leader to have received before considering a request complete. This controls the  durability of records that are sent. The following settings are allowed:  
+`acks`::
+*Type:* string +
+*Default:* 1 +
+*Valid Values:* [all, -1, 0, 1] +
+*Importance:* high +
++
+The number of acknowledgments the producer requires the leader to have received before considering a request complete. This controls the  durability of records that are sent. The following settings are allowed:  
  
 * `acks=0` If set to zero then the producer will not wait for any acknowledgment from the server at all. The record will be immediately added to the socket buffer and considered sent. No guarantee can be made that the server has received the record in this case, and the `retries` configuration will not take effect (as the client won't generally know of any failures). The offset given back for each record will always be set to -1. 
 * `acks=1` This will mean the leader will write the record to its local log but will respond without awaiting full acknowledgement from all followers. In this case should the leader fail immediately after acknowledging the record but before the followers have replicated it then the record will be lost. 
 * `acks=all` This means the leader will wait for the full set of in-sync replicas to acknowledge the record. This guarantees that the record will not be lost as long as at least one in-sync replica remains alive. This is the strongest available guarantee. This is equivalent to the acks=-1 setting.
-¦string
-¦1
-¦[all, -1, 0, 1]
-¦high
 
-¦`bootstrap.servers`
-a¦A list of host/port pairs to use for establishing the initial connection to the Kafka cluster. The client will make use of all servers irrespective of which servers are specified here for bootstrapping&mdash;this list only impacts the initial hosts used to discover the full set of servers. This list should be in the form `host1:port1,host2:port2,...`. Since these servers are just used for the initial connection to discover the full cluster membership (which may change dynamically), this list need not contain the full set of servers (you may want more than one, though, in case a server is down).
-¦list
-¦""
-¦non-null value
-¦high
+`bootstrap.servers`::
+*Type:* list +
+*Default:* "" +
+*Valid Values:* non-null value +
+*Importance:* high +
++
+A list of host/port pairs to use for establishing the initial connection to the Kafka cluster. The client will make use of all servers irrespective of which servers are specified here for bootstrapping&mdash;this list only impacts the initial hosts used to discover the full set of servers. This list should be in the form `host1:port1,host2:port2,...`. Since these servers are just used for the initial connection to discover the full cluster membership (which may change dynamically), this list need not contain the full set of servers (you may want more than one, though, in case a server is down).
 
-¦`buffer.memory`
-a¦The total bytes of memory the producer can use to buffer records waiting to be sent to the server. If records are sent faster than they can be delivered to the server the producer will block for `max.block.ms` after which it will throw an exception.
+`buffer.memory`::
+*Type:* long +
+*Default:* 33554432 +
+*Valid Values:* [0,...] +
+*Importance:* high +
++
+The total bytes of memory the producer can use to buffer records waiting to be sent to the server. If records are sent faster than they can be delivered to the server the producer will block for `max.block.ms` after which it will throw an exception.
++
 This setting should correspond roughly to the total memory the producer will use, but is not a hard bound since not all memory the producer uses is used for buffering. Some additional memory will be used for compression (if compression is enabled) as well as for maintaining in-flight requests.
-¦long
-¦33554432
-¦[0,...]
-¦high
 
-¦`compression.type`
-a¦The compression type for all data generated by the producer. The default is none (i.e. no compression). Valid  values are `none`, `gzip`, `snappy`, or `lz4`. Compression is of full batches of data, so the efficacy of batching will also impact the compression ratio (more batching means better compression).
-¦string
-¦none
-¦
-¦high
+`compression.type`::
+*Type:* string +
+*Default:* none +
+*Importance:* high +
++
+The compression type for all data generated by the producer. The default is none (i.e. no compression). Valid  values are `none`, `gzip`, `snappy`, or `lz4`. Compression is of full batches of data, so the efficacy of batching will also impact the compression ratio (more batching means better compression).
 
-¦`retries`
-a¦Setting a value greater than zero will cause the client to resend any record whose send fails with a potentially transient error. Note that this retry is no different than if the client resent the record upon receiving the error. Allowing retries without setting `max.in.flight.requests.per.connection` to 1 will potentially change the ordering of records because if two batches are sent to a single partition, and the first fails and is retried but the second succeeds, then the records in the second batch may appear first.
-¦int
-¦0
-¦[0,...,2147483647]
-¦high
+`retries`::
+*Type:* int +
+*Default:* 0 +
+*Valid Values:* [0,...,2147483647] +
+*Importance:* high +
++
+Setting a value greater than zero will cause the client to resend any record whose send fails with a potentially transient error. Note that this retry is no different than if the client resent the record upon receiving the error. Allowing retries without setting `max.in.flight.requests.per.connection` to 1 will potentially change the ordering of records because if two batches are sent to a single partition, and the first fails and is retried but the second succeeds, then the records in the second batch may appear first.
 
-¦`ssl.key.password`
-a¦The password of the private key in the key store file. This is optional for client.
-¦password
-¦null
-¦
-¦high
+`ssl.key.password`::
+*Type:* password +
+*Default:* null +
+*Importance:* high +
++
+The password of the private key in the key store file. This is optional for client.
 
-¦`ssl.keystore.location`
-a¦The location of the key store file. This is optional for client and can be used for two-way authentication for client.
-¦string
-¦null
-¦
-¦high
+`ssl.keystore.location`::
+*Type:* string +
+*Default:* null +
+*Importance:* high +
++
+The location of the key store file. This is optional for client and can be used for two-way authentication for client.
 
-¦`ssl.keystore.password`
-a¦The store password for the key store file. This is optional for client and only needed if ssl.keystore.location is configured. 
-¦password
-¦null
-¦
-¦high
+`ssl.keystore.password`::
+*Type:* password +
+*Default:* null +
+*Importance:* high +
++
+The store password for the key store file. This is optional for client and only needed if ssl.keystore.location is configured.
 
-¦`ssl.truststore.location`
-a¦The location of the trust store file. 
-¦string
-¦null
-¦
-¦high
+`ssl.truststore.location`::
+*Type:* string +
+*Default:* null +
+*Importance:* high +
++
+The location of the trust store file.
 
-¦`ssl.truststore.password`
-a¦The password for the trust store file. If a password is not set access to the truststore is still available, but integrity checking is disabled.
-¦password
-¦null
-¦
-¦high
+`ssl.truststore.password`::
+*Type:* password +
+*Default:* null +
+*Importance:* high +
++
+The password for the trust store file. If a password is not set access to the truststore is still available, but integrity checking is disabled.
 
-¦`batch.size`
-a¦The producer will attempt to batch records together into fewer requests whenever multiple records are being sent to the same partition. This helps performance on both the client and the server. This configuration controls the default batch size in bytes. 
+`batch.size`::
+*Type:* int +
+*Default:* 16384 +
+*Valid Values:* [0,...] +
+*Importance:* medium +
++
+The producer will attempt to batch records together into fewer requests whenever multiple records are being sent to the same partition. This helps performance on both the client and the server. This configuration controls the default batch size in bytes. 
++
 No attempt will be made to batch records larger than this size. 
++
 Requests sent to brokers will contain multiple batches, one for each partition with data available to be sent. 
++
 A small batch size will make batching less common and may reduce throughput (a batch size of zero will disable batching entirely). A very large batch size may use memory a bit more wastefully as we will always allocate a buffer of the specified batch size in anticipation of additional records.
-¦int
-¦16384
-¦[0,...]
-¦medium
 
-¦`client.id`
-a¦An id string to pass to the server when making requests. The purpose of this is to be able to track the source of requests beyond just ip/port by allowing a logical application name to be included in server-side request logging.
-¦string
-¦""
-¦
-¦medium
+`client.id`::
+*Type:* string +
+*Default:* "" +
+*Importance:* medium +
++
+An id string to pass to the server when making requests. The purpose of this is to be able to track the source of requests beyond just ip/port by allowing a logical application name to be included in server-side request logging.
 
-¦`connections.max.idle.ms`
-a¦Close idle connections after the number of milliseconds specified by this config.
-¦long
-¦540000
-¦
-¦medium
+`connections.max.idle.ms`::
+*Type:* long +
+*Default:* 540000 +
+*Importance:* medium +
++
+Close idle connections after the number of milliseconds specified by this config.
 
-¦`linger.ms`
-a¦The producer groups together any records that arrive in between request transmissions into a single batched request. Normally this occurs only under load when records arrive faster than they can be sent out. However in some circumstances the client may want to reduce the number of requests even under moderate load. This setting accomplishes this by adding a small amount of artificial delay&mdash;that is, rather than immediately sending out a record the producer will wait for up to the given delay to allow other records to be sent so that the sends can be batched together. This can be thought of as analogous to Nagle's algorithm in TCP. This setting gives the upper bound on the delay for batching: once we get `batch.size` worth of records for a partition it will be sent immediately regardless of this setting, however if we have fewer than this many bytes accumulated for this partition we will 'linger' for the specified time waiting for more records to show up. This setting defaults to 0 (i.e. no delay). Setting `linger.ms=5`, for example, would have the effect of reducing the number of requests sent but would add up to 5ms of latency to records sent in the absence of load.
-¦long
-¦0
-¦[0,...]
-¦medium
+`linger.ms`::
+*Type:* long +
+*Default:* 0 +
+*Valid Values:* [0,...] +
+*Importance:* medium +
++
+The producer groups together any records that arrive in between request transmissions into a single batched request. Normally this occurs only under load when records arrive faster than they can be sent out. However in some circumstances the client may want to reduce the number of requests even under moderate load. This setting accomplishes this by adding a small amount of artificial delay&mdash;that is, rather than immediately sending out a record the producer will wait for up to the given delay to allow other records to be sent so that the sends can be batched together. This can be thought of as analogous to Nagle's algorithm in TCP. This setting gives the upper bound on the delay for batching: once we get `batch.size` worth of records for a partition it will be sent immediately regardless of this setting, however if we have fewer than this many bytes accumulated for this partition we will 'linger' for the specified time waiting for more records to show up. This setting defaults to 0 (i.e. no delay). Setting `linger.ms=5`, for example, would have the effect of reducing the number of requests sent but would add up to 5ms of latency to records sent in the absence of load.
 
-¦`max.block.ms`
-a¦The configuration controls how long `KafkaProducer.send()` and `KafkaProducer.partitionsFor()` will block.These methods can be blocked either because the buffer is full or metadata unavailable.Blocking in the user-supplied serializers or partitioner will not be counted against this timeout.
-¦long
-¦60000
-¦[0,...]
-¦medium
+`max.block.ms`::
+*Type:* long +
+*Default:* 60000 +
+*Valid Values:* [0,...] +
+*Importance:* medium +
++
+The configuration controls how long `KafkaProducer.send()` and `KafkaProducer.partitionsFor()` will block.These methods can be blocked either because the buffer is full or metadata unavailable.Blocking in the user-supplied serializers or partitioner will not be counted against this timeout.
 
-¦`max.request.size`
-a¦The maximum size of a request in bytes. This setting will limit the number of record batches the producer will send in a single request to avoid sending huge requests. This is also effectively a cap on the maximum record batch size. Note that the server has its own cap on record batch size which may be different from this.
-¦int
-¦1048576
-¦[0,...]
-¦medium
+`max.request.size`::
+*Type:* int +
+*Default:* 1048576 +
+*Valid Values:* [0,...] +
+*Importance:* medium +
++
+The maximum size of a request in bytes. This setting will limit the number of record batches the producer will send in a single request to avoid sending huge requests. This is also effectively a cap on the maximum record batch size. Note that the server has its own cap on record batch size which may be different from this.
 
-¦`partitioner.class`
-a¦Partitioner class that implements the `org.apache.kafka.clients.producer.Partitioner` interface.
-¦class
-¦org.apache.kafka.clients.producer.internals.DefaultPartitioner
-¦
-¦medium
+`partitioner.class`::
+*Type:* class +
+*Default:* org.apache.kafka.clients.producer.internals.DefaultPartitioner +
+*Importance:* medium +
++
+Partitioner class that implements the `org.apache.kafka.clients.producer.Partitioner` interface.
 
-¦`receive.buffer.bytes`
-a¦The size of the TCP receive buffer (SO_RCVBUF) to use when reading data. If the value is -1, the OS default will be used.
-¦int
-¦32768
-¦[-1,...]
-¦medium
+`receive.buffer.bytes`::
+*Type:* int +
+*Default:* 32768 +
+*Valid Values:* [-1,...] +
+*Importance:* medium +
++
+The size of the TCP receive buffer (SO_RCVBUF) to use when reading data. If the value is -1, the OS default will be used.
 
-¦`request.timeout.ms`
-a¦The configuration controls the maximum amount of time the client will wait for the response of a request. If the response is not received before the timeout elapses the client will resend the request if necessary or fail the request if retries are exhausted. This should be larger than replica.lag.time.max.ms (a broker configuration) to reduce the possibility of message duplication due to unnecessary producer retries.
-¦int
-¦30000
-¦[0,...]
-¦medium
+`request.timeout.ms`::
+*Type:* int +
+*Default:* 30000 +
+*Valid Values:* [0,...] +
+*Importance:* medium +
++
+The configuration controls the maximum amount of time the client will wait for the response of a request. If the response is not received before the timeout elapses the client will resend the request if necessary or fail the request if retries are exhausted. This should be larger than replica.lag.time.max.ms (a broker configuration) to reduce the possibility of message duplication due to unnecessary producer retries.
 
-¦`sasl.client.callback.handler.class`
-a¦The fully qualified name of a SASL client callback handler class that implements the AuthenticateCallbackHandler interface.
-¦class
-¦null
-¦
-¦medium
+`sasl.client.callback.handler.class`::
+*Type:* class +
+*Default:* null +
+*Importance:* medium +
++
+The fully qualified name of a SASL client callback handler class that implements the AuthenticateCallbackHandler interface.
 
-¦`sasl.jaas.config`
-a¦JAAS login context parameters for SASL connections in the format used by JAAS configuration files. JAAS configuration file format is described http://docs.oracle.com/javase/8/docs/technotes/guides/security/jgss/tutorials/LoginConfigFile.html[here]. The format for the value is: '`loginModuleClass controlFlag (optionName=optionValue)*;`'. For brokers, the config must be prefixed with listener prefix and SASL mechanism name in lower-case. For example, listener.name.sasl_ssl.scram-sha-256.sasl.jaas.config=com.example.ScramLoginModule required;
-¦password
-¦null
-¦
-¦medium
+`sasl.jaas.config`::
+*Type:* password +
+*Default:* null +
+*Importance:* medium +
++
+JAAS login context parameters for SASL connections in the format used by JAAS configuration files. JAAS configuration file format is described http://docs.oracle.com/javase/8/docs/technotes/guides/security/jgss/tutorials/LoginConfigFile.html[here]. The format for the value is: '`loginModuleClass controlFlag (optionName=optionValue)*;`'. For brokers, the config must be prefixed with listener prefix and SASL mechanism name in lower-case. For example, listener.name.sasl_ssl.scram-sha-256.sasl.jaas.config=com.example.ScramLoginModule required;.
 
-¦`sasl.kerberos.service.name`
-a¦The Kerberos principal name that Kafka runs as. This can be defined either in Kafka's JAAS config or in Kafka's config.
-¦string
-¦null
-¦
-¦medium
+`sasl.kerberos.service.name`::
+*Type:* string +
+*Default:* null +
+*Importance:* medium +
++
+The Kerberos principal name that Kafka runs as. This can be defined either in Kafka's JAAS config or in Kafka's config.
 
-¦`sasl.login.callback.handler.class`
-a¦The fully qualified name of a SASL login callback handler class that implements the AuthenticateCallbackHandler interface. For brokers, login callback handler config must be prefixed with listener prefix and SASL mechanism name in lower-case. For example, listener.name.sasl_ssl.scram-sha-256.sasl.login.callback.handler.class=com.example.CustomScramLoginCallbackHandler
-¦class
-¦null
-¦
-¦medium
+`sasl.login.callback.handler.class`::
+*Type:* class +
+*Default:* null +
+*Importance:* medium +
++
+The fully qualified name of a SASL login callback handler class that implements the AuthenticateCallbackHandler interface. For brokers, login callback handler config must be prefixed with listener prefix and SASL mechanism name in lower-case. For example, listener.name.sasl_ssl.scram-sha-256.sasl.login.callback.handler.class=com.example.CustomScramLoginCallbackHandler.
 
-¦`sasl.login.class`
-a¦The fully qualified name of a class that implements the Login interface. For brokers, login config must be prefixed with listener prefix and SASL mechanism name in lower-case. For example, listener.name.sasl_ssl.scram-sha-256.sasl.login.class=com.example.CustomScramLogin
-¦class
-¦null
-¦
-¦medium
+`sasl.login.class`::
+*Type:* class +
+*Default:* null +
+*Importance:* medium +
++
+The fully qualified name of a class that implements the Login interface. For brokers, login config must be prefixed with listener prefix and SASL mechanism name in lower-case. For example, listener.name.sasl_ssl.scram-sha-256.sasl.login.class=com.example.CustomScramLogin.
 
-¦`sasl.mechanism`
-a¦SASL mechanism used for client connections. This may be any mechanism for which a security provider is available. GSSAPI is the default mechanism.
-¦string
-¦GSSAPI
-¦
-¦medium
+`sasl.mechanism`::
+*Type:* string +
+*Default:* GSSAPI +
+*Importance:* medium +
++
+SASL mechanism used for client connections. This may be any mechanism for which a security provider is available. GSSAPI is the default mechanism.
 
-¦`security.protocol`
-a¦Protocol used to communicate with brokers. Valid values are: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL.
-¦string
-¦PLAINTEXT
-¦
-¦medium
+`security.protocol`::
+*Type:* string +
+*Default:* PLAINTEXT +
+*Importance:* medium +
++
+Protocol used to communicate with brokers. Valid values are: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL.
 
-¦`send.buffer.bytes`
-a¦The size of the TCP send buffer (SO_SNDBUF) to use when sending data. If the value is -1, the OS default will be used.
-¦int
-¦131072
-¦[-1,...]
-¦medium
+`send.buffer.bytes`::
+*Type:* int +
+*Default:* 131072 +
+*Valid Values:* [-1,...] +
+*Importance:* medium +
++
+The size of the TCP send buffer (SO_SNDBUF) to use when sending data. If the value is -1, the OS default will be used.
 
-¦`ssl.enabled.protocols`
-a¦The list of protocols enabled for SSL connections.
-¦list
-¦TLSv1.2,TLSv1.1,TLSv1
-¦
-¦medium
+`ssl.enabled.protocols`::
+*Type:* list +
+*Default:* TLSv1.2,TLSv1.1,TLSv1 +
+*Importance:* medium +
++
+The list of protocols enabled for SSL connections.
 
-¦`ssl.keystore.type`
-a¦The file format of the key store file. This is optional for client.
-¦string
-¦JKS
-¦
-¦medium
+`ssl.keystore.type`::
+*Type:* string +
+*Default:* JKS +
+*Importance:* medium +
++
+The file format of the key store file. This is optional for client.
 
-¦`ssl.protocol`
-a¦The SSL protocol used to generate the SSLContext. Default setting is TLS, which is fine for most cases. Allowed values in recent JVMs are TLS, TLSv1.1 and TLSv1.2. SSL, SSLv2 and SSLv3 may be supported in older JVMs, but their usage is discouraged due to known security vulnerabilities.
-¦string
-¦TLS
-¦
-¦medium
+`ssl.protocol`::
+*Type:* string +
+*Default:* TLS +
+*Importance:* medium +
++
+The SSL protocol used to generate the SSLContext. Default setting is TLS, which is fine for most cases. Allowed values in recent JVMs are TLS, TLSv1.1 and TLSv1.2. SSL, SSLv2 and SSLv3 may be supported in older JVMs, but their usage is discouraged due to known security vulnerabilities.
 
-¦`ssl.provider`
-a¦The name of the security provider used for SSL connections. Default value is the default security provider of the JVM.
-¦string
-¦null
-¦
-¦medium
+`ssl.provider`::
+*Type:* string +
+*Default:* null +
+*Importance:* medium +
++
+The name of the security provider used for SSL connections. Default value is the default security provider of the JVM.
 
-¦`ssl.truststore.type`
-a¦The file format of the trust store file.
-¦string
-¦JKS
-¦
-¦medium
+`ssl.truststore.type`::
+*Type:* string +
+*Default:* JKS +
+*Importance:* medium +
++
+The file format of the trust store file.
 
-¦`enable.idempotence`
-a¦When set to 'true', the producer will ensure that exactly one copy of each message is written in the stream. If 'false', producer retries due to broker failures, etc., may write duplicates of the retried message in the stream. Note that enabling idempotence requires `max.in.flight.requests.per.connection` to be less than or equal to 5, `retries` to be greater than 0 and acks must be 'all'. If these values are not explicitly set by the user, suitable values will be chosen. If incompatible values are set, a ConfigException will be thrown.
-¦boolean
-¦false
-¦
-¦low
+`enable.idempotence`::
+*Type:* boolean +
+*Default:* false +
+*Importance:* low +
++
+When set to 'true', the producer will ensure that exactly one copy of each message is written in the stream. If 'false', producer retries due to broker failures, etc., may write duplicates of the retried message in the stream. Note that enabling idempotence requires `max.in.flight.requests.per.connection` to be less than or equal to 5, `retries` to be greater than 0 and acks must be 'all'. If these values are not explicitly set by the user, suitable values will be chosen. If incompatible values are set, a ConfigException will be thrown.
 
-¦`interceptor.classes`
-a¦A list of classes to use as interceptors. Implementing the `org.apache.kafka.clients.producer.ProducerInterceptor` interface allows you to intercept (and possibly mutate) the records received by the producer before they are published to the Kafka cluster. By default, there are no interceptors.
-¦list
-¦""
-¦non-null value
-¦low
+`interceptor.classes`::
+*Type:* list +
+*Default:* "" +
+*Valid Values:* non-null value +
+*Importance:* low +
++
+A list of classes to use as interceptors. Implementing the `org.apache.kafka.clients.producer.ProducerInterceptor` interface allows you to intercept (and possibly mutate) the records received by the producer before they are published to the Kafka cluster. By default, there are no interceptors.
 
-¦`max.in.flight.requests.per.connection`
-a¦The maximum number of unacknowledged requests the client will send on a single connection before blocking. Note that if this setting is set to be greater than 1 and there are failed sends, there is a risk of message re-ordering due to retries (i.e., if retries are enabled).
-¦int
-¦5
-¦[1,...]
-¦low
+`max.in.flight.requests.per.connection`::
+*Type:* int +
+*Default:* 5 +
+*Valid Values:* [1,...] +
+*Importance:* low +
++
+The maximum number of unacknowledged requests the client will send on a single connection before blocking. Note that if this setting is set to be greater than 1 and there are failed sends, there is a risk of message re-ordering due to retries (i.e., if retries are enabled).
 
-¦`metadata.max.age.ms`
-a¦The period of time in milliseconds after which we force a refresh of metadata even if we haven't seen any partition leadership changes to proactively discover any new brokers or partitions.
-¦long
-¦300000
-¦[0,...]
-¦low
+`metadata.max.age.ms`::
+*Type:* long +
+*Default:* 300000 +
+*Valid Values:* [0,...] +
+*Importance:* low +
++
+The period of time in milliseconds after which we force a refresh of metadata even if we haven't seen any partition leadership changes to proactively discover any new brokers or partitions.
 
-¦`metric.reporters`
-a¦A list of classes to use as metrics reporters. Implementing the `org.apache.kafka.common.metrics.MetricsReporter` interface allows plugging in classes that will be notified of new metric creation. The JmxReporter is always included to register JMX statistics.
-¦list
-¦""
-¦non-null value
-¦low
+`metric.reporters`::
+*Type:* list +
+*Default:* "" +
+*Valid Values:* non-null value +
+*Importance:* low +
++
+A list of classes to use as metrics reporters. Implementing the `org.apache.kafka.common.metrics.MetricsReporter` interface allows plugging in classes that will be notified of new metric creation. The JmxReporter is always included to register JMX statistics.
 
-¦`metrics.num.samples`
-a¦The number of samples maintained to compute metrics.
-¦int
-¦2
-¦[1,...]
-¦low
+`metrics.num.samples`::
+*Type:* int +
+*Default:* 2 +
+*Valid Values:* [1,...] +
+*Importance:* low +
++
+The number of samples maintained to compute metrics.
 
-¦`metrics.recording.level`
-a¦The highest recording level for metrics.
-¦string
-¦INFO
-¦[INFO, DEBUG]
-¦low
+`metrics.recording.level`::
+*Type:* string +
+*Default:* INFO +
+*Valid Values:* [INFO, DEBUG] +
+*Importance:* low +
++
+The highest recording level for metrics.
 
-¦`metrics.sample.window.ms`
-a¦The window of time a metrics sample is computed over.
-¦long
-¦30000
-¦[0,...]
-¦low
+`metrics.sample.window.ms`::
+*Type:* long +
+*Default:* 30000 +
+*Valid Values:* [0,...] +
+*Importance:* low +
++
+The window of time a metrics sample is computed over.
 
-¦`reconnect.backoff.max.ms`
-a¦The maximum amount of time in milliseconds to wait when reconnecting to a broker that has repeatedly failed to connect. If provided, the backoff per host will increase exponentially for each consecutive connection failure, up to this maximum. After calculating the backoff increase, 20% random jitter is added to avoid connection storms.
-¦long
-¦1000
-¦[0,...]
-¦low
+`reconnect.backoff.max.ms`::
+*Type:* long +
+*Default:* 1000 +
+*Valid Values:* [0,...] +
+*Importance:* low +
++
+The maximum amount of time in milliseconds to wait when reconnecting to a broker that has repeatedly failed to connect. If provided, the backoff per host will increase exponentially for each consecutive connection failure, up to this maximum. After calculating the backoff increase, 20% random jitter is added to avoid connection storms.
 
-¦`reconnect.backoff.ms`
-a¦The base amount of time to wait before attempting to reconnect to a given host. This avoids repeatedly connecting to a host in a tight loop. This backoff applies to all connection attempts by the client to a broker.
-¦long
-¦50
-¦[0,...]
-¦low
+`reconnect.backoff.ms`::
+*Type:* long +
+*Default:* 50 +
+*Valid Values:* [0,...] +
+*Importance:* low +
++
+The base amount of time to wait before attempting to reconnect to a given host. This avoids repeatedly connecting to a host in a tight loop. This backoff applies to all connection attempts by the client to a broker.
 
-¦`retry.backoff.ms`
-a¦The amount of time to wait before attempting to retry a failed request to a given topic partition. This avoids repeatedly sending requests in a tight loop under some failure scenarios.
-¦long
-¦100
-¦[0,...]
-¦low
+`retry.backoff.ms`::
+*Type:* long +
+*Default:* 100 +
+*Valid Values:* [0,...] +
+*Importance:* low +
++
+The amount of time to wait before attempting to retry a failed request to a given topic partition. This avoids repeatedly sending requests in a tight loop under some failure scenarios.
 
-¦`sasl.kerberos.kinit.cmd`
-a¦Kerberos kinit command path.
-¦string
-¦/usr/bin/kinit
-¦
-¦low
+`sasl.kerberos.kinit.cmd`::
+*Type:* string +
+*Default:* /usr/bin/kinit +
+*Importance:* low +
++
+Kerberos kinit command path.
 
-¦`sasl.kerberos.min.time.before.relogin`
-a¦Login thread sleep time between refresh attempts.
-¦long
-¦60000
-¦
-¦low
+`sasl.kerberos.min.time.before.relogin`::
+*Type:* long +
+*Default:* 60000 +
+*Importance:* low +
++
+Login thread sleep time between refresh attempts.
 
-¦`sasl.kerberos.ticket.renew.jitter`
-a¦Percentage of random jitter added to the renewal time.
-¦double
-¦0.05
-¦
-¦low
+`sasl.kerberos.ticket.renew.jitter`::
+*Type:* double +
+*Default:* 0.05 +
+*Importance:* low +
++
+Percentage of random jitter added to the renewal time.
 
-¦`sasl.kerberos.ticket.renew.window.factor`
-a¦Login thread will sleep until the specified window factor of time from last refresh to ticket's expiry has been reached, at which time it will try to renew the ticket.
-¦double
-¦0.8
-¦
-¦low
+`sasl.kerberos.ticket.renew.window.factor`::
+*Type:* double +
+*Default:* 0.8 +
+*Importance:* low +
++
+Login thread will sleep until the specified window factor of time from last refresh to ticket's expiry has been reached, at which time it will try to renew the ticket.
 
-¦`sasl.login.refresh.buffer.seconds`
-a¦The amount of buffer time before credential expiration to maintain when refreshing a credential, in seconds. If a refresh would otherwise occur closer to expiration than the number of buffer seconds then the refresh will be moved up to maintain as much of the buffer time as possible. Legal values are between 0 and 3600 (1 hour); a default value of  300 (5 minutes) is used if no value is specified. This value and sasl.login.refresh.min.period.seconds are both ignored if their sum exceeds the remaining lifetime of a credential. Currently applies only to OAUTHBEARER.
-¦short
-¦300
-¦[0,...,3600]
-¦low
+`sasl.login.refresh.buffer.seconds`::
+*Type:* short +
+*Default:* 300 +
+*Valid Values:* [0,...,3600] +
+*Importance:* low +
++
+The amount of buffer time before credential expiration to maintain when refreshing a credential, in seconds. If a refresh would otherwise occur closer to expiration than the number of buffer seconds then the refresh will be moved up to maintain as much of the buffer time as possible. Legal values are between 0 and 3600 (1 hour); a default value of  300 (5 minutes) is used if no value is specified. This value and sasl.login.refresh.min.period.seconds are both ignored if their sum exceeds the remaining lifetime of a credential. Currently applies only to OAUTHBEARER.
 
-¦`sasl.login.refresh.min.period.seconds`
-a¦The desired minimum time for the login refresh thread to wait before refreshing a credential, in seconds. Legal values are between 0 and 900 (15 minutes); a default value of 60 (1 minute) is used if no value is specified.  This value and  sasl.login.refresh.buffer.seconds are both ignored if their sum exceeds the remaining lifetime of a credential. Currently applies only to OAUTHBEARER.
-¦short
-¦60
-¦[0,...,900]
-¦low
+`sasl.login.refresh.min.period.seconds`::
+*Type:* short +
+*Default:* 60 +
+*Valid Values:* [0,...,900] +
+*Importance:* low +
++
+The desired minimum time for the login refresh thread to wait before refreshing a credential, in seconds. Legal values are between 0 and 900 (15 minutes); a default value of 60 (1 minute) is used if no value is specified.  This value and  sasl.login.refresh.buffer.seconds are both ignored if their sum exceeds the remaining lifetime of a credential. Currently applies only to OAUTHBEARER.
 
-¦`sasl.login.refresh.window.factor`
-a¦Login refresh thread will sleep until the specified window factor relative to the credential's lifetime has been reached, at which time it will try to refresh the credential. Legal values are between 0.5 (50%) and 1.0 (100%) inclusive; a default value of 0.8 (80%) is used if no value is specified. Currently applies only to OAUTHBEARER.
-¦double
-¦0.8
-¦[0.5,...,1.0]
-¦low
+`sasl.login.refresh.window.factor`::
+*Type:* double +
+*Default:* 0.8 +
+*Valid Values:* [0.5,...,1.0] +
+*Importance:* low +
++
+Login refresh thread will sleep until the specified window factor relative to the credential's lifetime has been reached, at which time it will try to refresh the credential. Legal values are between 0.5 (50%) and 1.0 (100%) inclusive; a default value of 0.8 (80%) is used if no value is specified. Currently applies only to OAUTHBEARER.
 
-¦`sasl.login.refresh.window.jitter`
-a¦The maximum amount of random jitter relative to the credential's lifetime that is added to the login refresh thread's sleep time. Legal values are between 0 and 0.25 (25%) inclusive; a default value of 0.05 (5%) is used if no value is specified. Currently applies only to OAUTHBEARER.
-¦double
-¦0.05
-¦[0.0,...,0.25]
-¦low
+`sasl.login.refresh.window.jitter`::
+*Type:* double +
+*Default:* 0.05 +
+*Valid Values:* [0.0,...,0.25] +
+*Importance:* low +
++
+The maximum amount of random jitter relative to the credential's lifetime that is added to the login refresh thread's sleep time. Legal values are between 0 and 0.25 (25%) inclusive; a default value of 0.05 (5%) is used if no value is specified. Currently applies only to OAUTHBEARER.
 
-¦`ssl.cipher.suites`
-a¦A list of cipher suites. This is a named combination of authentication, encryption, MAC and key exchange algorithm used to negotiate the security settings for a network connection using TLS or SSL network protocol. By default all the available cipher suites are supported.
-¦list
-¦null
-¦
-¦low
+`ssl.cipher.suites`::
+*Type:* list +
+*Default:* null +
+*Importance:* low +
++
+A list of cipher suites. This is a named combination of authentication, encryption, MAC and key exchange algorithm used to negotiate the security settings for a network connection using TLS or SSL network protocol. By default all the available cipher suites are supported.
 
-¦`ssl.endpoint.identification.algorithm`
-a¦The endpoint identification algorithm to validate server hostname using server certificate. 
-¦string
-¦https
-¦
-¦low
+`ssl.endpoint.identification.algorithm`::
+*Type:* string +
+*Default:* https +
+*Importance:* low +
++
+The endpoint identification algorithm to validate server hostname using server certificate.
 
-¦`ssl.keymanager.algorithm`
-a¦The algorithm used by key manager factory for SSL connections. Default value is the key manager factory algorithm configured for the Java Virtual Machine.
-¦string
-¦SunX509
-¦
-¦low
+`ssl.keymanager.algorithm`::
+*Type:* string +
+*Default:* SunX509 +
+*Importance:* low +
++
+The algorithm used by key manager factory for SSL connections. Default value is the key manager factory algorithm configured for the Java Virtual Machine.
 
-¦`ssl.secure.random.implementation`
-a¦The SecureRandom PRNG implementation to use for SSL cryptography operations. 
-¦string
-¦null
-¦
-¦low
+`ssl.secure.random.implementation`::
+*Type:* string +
+*Default:* null +
+*Importance:* low +
++
+The SecureRandom PRNG implementation to use for SSL cryptography operations.
 
-¦`ssl.trustmanager.algorithm`
-a¦The algorithm used by trust manager factory for SSL connections. Default value is the trust manager factory algorithm configured for the Java Virtual Machine.
-¦string
-¦PKIX
-¦
-¦low
+`ssl.trustmanager.algorithm`::
+*Type:* string +
+*Default:* PKIX +
+*Importance:* low +
++
+The algorithm used by trust manager factory for SSL connections. Default value is the trust manager factory algorithm configured for the Java Virtual Machine.
 
-¦`transaction.timeout.ms`
-a¦The maximum amount of time in ms that the transaction coordinator will wait for a transaction status update from the producer before proactively aborting the ongoing transaction.If this value is larger than the transaction.max.timeout.ms setting in the broker, the request will fail with a `InvalidTransactionTimeout` error.
-¦int
-¦60000
-¦
-¦low
+`transaction.timeout.ms`::
+*Type:* int +
+*Default:* 60000 +
+*Importance:* low +
++
+The maximum amount of time in ms that the transaction coordinator will wait for a transaction status update from the producer before proactively aborting the ongoing transaction.If this value is larger than the transaction.max.timeout.ms setting in the broker, the request will fail with a `InvalidTransactionTimeout` error.
 
-¦`transactional.id`
-a¦The TransactionalId to use for transactional delivery. This enables reliability semantics which span multiple producer sessions since it allows the client to guarantee that transactions using the same TransactionalId have been completed prior to starting any new transactions. If no TransactionalId is provided, then the producer is limited to idempotent delivery. Note that enable.idempotence must be enabled if a TransactionalId is configured. The default is `null`, which means transactions cannot be used. Note that transactions requires a cluster of at least three brokers by default what is the recommended setting for production; for development you can change this, by adjusting broker setting `transaction.state.log.replication.factor`.
-¦string
-¦null
-¦non-empty string
-¦low
-
-|=====
+`transactional.id`::
+*Type:* string +
+*Default:* null +
+*Valid Values:* non-empty string +
+*Importance:* low +
++
+The TransactionalId to use for transactional delivery. This enables reliability semantics which span multiple producer sessions since it allows the client to guarantee that transactions using the same TransactionalId have been completed prior to starting any new transactions. If no TransactionalId is provided, then the producer is limited to idempotent delivery. Note that enable.idempotence must be enabled if a TransactionalId is configured. The default is `null`, which means transactions cannot be used. Note that transactions requires a cluster of at least three brokers by default what is the recommended setting for production; for development you can change this, by adjusting broker setting `transaction.state.log.replication.factor`.

--- a/books/ref-streams-config.adoc
+++ b/books/ref-streams-config.adoc
@@ -1,278 +1,288 @@
 // Module included in the following assemblies:
 //
 // assembly-overview.adoc
+//
+// THIS FILE IS AUTO-GENERATED. DO NOT EDIT BY HAND
+// Run "make clean buildall" to regenerate.
 
 [id='kafka-streams-configuration-parameters-{context}']
 = Kafka Streams configuration parameters
 
-[cols="6",options="header",separator=¦]
-|=====
-¦Name ¦Description ¦Type ¦Default ¦Valid Values ¦Importance 
+`application.id`::
+*Type:* string +
+*Importance:* high +
++
+An identifier for the stream processing application. Must be unique within the Kafka cluster. It is used as 1) the default client-id prefix, 2) the group-id for membership management, 3) the changelog topic prefix.
 
-¦`application.id`
-a¦An identifier for the stream processing application. Must be unique within the Kafka cluster. It is used as 1) the default client-id prefix, 2) the group-id for membership management, 3) the changelog topic prefix.
-¦string
-¦
-¦
-¦high
+`bootstrap.servers`::
+*Type:* list +
+*Importance:* high +
++
+A list of host/port pairs to use for establishing the initial connection to the Kafka cluster. The client will make use of all servers irrespective of which servers are specified here for bootstrapping&mdash;this list only impacts the initial hosts used to discover the full set of servers. This list should be in the form `host1:port1,host2:port2,...`. Since these servers are just used for the initial connection to discover the full cluster membership (which may change dynamically), this list need not contain the full set of servers (you may want more than one, though, in case a server is down).
 
-¦`bootstrap.servers`
-a¦A list of host/port pairs to use for establishing the initial connection to the Kafka cluster. The client will make use of all servers irrespective of which servers are specified here for bootstrapping&mdash;this list only impacts the initial hosts used to discover the full set of servers. This list should be in the form `host1:port1,host2:port2,...`. Since these servers are just used for the initial connection to discover the full cluster membership (which may change dynamically), this list need not contain the full set of servers (you may want more than one, though, in case a server is down).
-¦list
-¦
-¦
-¦high
+`replication.factor`::
+*Type:* int +
+*Default:* 1 +
+*Importance:* high +
++
+The replication factor for change log topics and repartition topics created by the stream processing application.
 
-¦`replication.factor`
-a¦The replication factor for change log topics and repartition topics created by the stream processing application.
-¦int
-¦1
-¦
-¦high
+`state.dir`::
+*Type:* string +
+*Default:* /tmp/kafka-streams +
+*Importance:* high +
++
+Directory location for state store.
 
-¦`state.dir`
-a¦Directory location for state store.
-¦string
-¦/tmp/kafka-streams
-¦
-¦high
+`cache.max.bytes.buffering`::
+*Type:* long +
+*Default:* 10485760 +
+*Valid Values:* [0,...] +
+*Importance:* medium +
++
+Maximum number of memory bytes to be used for buffering across all threads.
 
-¦`cache.max.bytes.buffering`
-a¦Maximum number of memory bytes to be used for buffering across all threads
-¦long
-¦10485760
-¦[0,...]
-¦medium
+`client.id`::
+*Type:* string +
+*Default:* "" +
+*Importance:* medium +
++
+An ID prefix string used for the client IDs of internal consumer, producer and restore-consumer, with pattern '<client.id>-StreamThread-<threadSequenceNumber>-<consumer|producer|restore-consumer>'.
 
-¦`client.id`
-a¦An ID prefix string used for the client IDs of internal consumer, producer and restore-consumer, with pattern '<client.id>-StreamThread-<threadSequenceNumber>-<consumer|producer|restore-consumer>'.
-¦string
-¦""
-¦
-¦medium
+`default.deserialization.exception.handler`::
+*Type:* class +
+*Default:* org.apache.kafka.streams.errors.LogAndFailExceptionHandler +
+*Importance:* medium +
++
+Exception handling class that implements the `org.apache.kafka.streams.errors.DeserializationExceptionHandler` interface.
 
-¦`default.deserialization.exception.handler`
-a¦Exception handling class that implements the `org.apache.kafka.streams.errors.DeserializationExceptionHandler` interface.
-¦class
-¦org.apache.kafka.streams.errors.LogAndFailExceptionHandler
-¦
-¦medium
+`default.key.serde`::
+*Type:* class +
+*Default:* org.apache.kafka.common.serialization.Serdes$ByteArraySerde +
+*Importance:* medium +
++
+Default serializer / deserializer class for key that implements the `org.apache.kafka.common.serialization.Serde` interface. Note when windowed serde class is used, one needs to set the inner serde class that implements the `org.apache.kafka.common.serialization.Serde` interface via 'default.windowed.key.serde.inner' or 'default.windowed.value.serde.inner' as well.
 
-¦`default.key.serde`
-a¦ Default serializer / deserializer class for key that implements the `org.apache.kafka.common.serialization.Serde` interface. Note when windowed serde class is used, one needs to set the inner serde class that implements the `org.apache.kafka.common.serialization.Serde` interface via 'default.windowed.key.serde.inner' or 'default.windowed.value.serde.inner' as well
-¦class
-¦org.apache.kafka.common.serialization.Serdes$ByteArraySerde
-¦
-¦medium
+`default.production.exception.handler`::
+*Type:* class +
+*Default:* org.apache.kafka.streams.errors.DefaultProductionExceptionHandler +
+*Importance:* medium +
++
+Exception handling class that implements the `org.apache.kafka.streams.errors.ProductionExceptionHandler` interface.
 
-¦`default.production.exception.handler`
-a¦Exception handling class that implements the `org.apache.kafka.streams.errors.ProductionExceptionHandler` interface.
-¦class
-¦org.apache.kafka.streams.errors.DefaultProductionExceptionHandler
-¦
-¦medium
+`default.timestamp.extractor`::
+*Type:* class +
+*Default:* org.apache.kafka.streams.processor.FailOnInvalidTimestamp +
+*Importance:* medium +
++
+Default timestamp extractor class that implements the `org.apache.kafka.streams.processor.TimestampExtractor` interface.
 
-¦`default.timestamp.extractor`
-a¦Default timestamp extractor class that implements the `org.apache.kafka.streams.processor.TimestampExtractor` interface.
-¦class
-¦org.apache.kafka.streams.processor.FailOnInvalidTimestamp
-¦
-¦medium
+`default.value.serde`::
+*Type:* class +
+*Default:* org.apache.kafka.common.serialization.Serdes$ByteArraySerde +
+*Importance:* medium +
++
+Default serializer / deserializer class for value that implements the `org.apache.kafka.common.serialization.Serde` interface. Note when windowed serde class is used, one needs to set the inner serde class that implements the `org.apache.kafka.common.serialization.Serde` interface via 'default.windowed.key.serde.inner' or 'default.windowed.value.serde.inner' as well.
 
-¦`default.value.serde`
-a¦Default serializer / deserializer class for value that implements the `org.apache.kafka.common.serialization.Serde` interface. Note when windowed serde class is used, one needs to set the inner serde class that implements the `org.apache.kafka.common.serialization.Serde` interface via 'default.windowed.key.serde.inner' or 'default.windowed.value.serde.inner' as well
-¦class
-¦org.apache.kafka.common.serialization.Serdes$ByteArraySerde
-¦
-¦medium
+`num.standby.replicas`::
+*Type:* int +
+*Default:* 0 +
+*Importance:* medium +
++
+The number of standby replicas for each task.
 
-¦`num.standby.replicas`
-a¦The number of standby replicas for each task.
-¦int
-¦0
-¦
-¦medium
+`num.stream.threads`::
+*Type:* int +
+*Default:* 1 +
+*Importance:* medium +
++
+The number of threads to execute stream processing.
 
-¦`num.stream.threads`
-a¦The number of threads to execute stream processing.
-¦int
-¦1
-¦
-¦medium
+`processing.guarantee`::
+*Type:* string +
+*Default:* at_least_once +
+*Valid Values:* [at_least_once, exactly_once] +
+*Importance:* medium +
++
+The processing guarantee that should be used. Possible values are `at_least_once` (default) and `exactly_once`. Note that exactly-once processing requires a cluster of at least three brokers by default what is the recommended setting for production; for development you can change this, by adjusting broker setting `transaction.state.log.replication.factor`.
 
-¦`processing.guarantee`
-a¦The processing guarantee that should be used. Possible values are `at_least_once` (default) and `exactly_once`. Note that exactly-once processing requires a cluster of at least three brokers by default what is the recommended setting for production; for development you can change this, by adjusting broker setting `transaction.state.log.replication.factor`.
-¦string
-¦at_least_once
-¦[at_least_once, exactly_once]
-¦medium
+`security.protocol`::
+*Type:* string +
+*Default:* PLAINTEXT +
+*Importance:* medium +
++
+Protocol used to communicate with brokers. Valid values are: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL.
 
-¦`security.protocol`
-a¦Protocol used to communicate with brokers. Valid values are: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL.
-¦string
-¦PLAINTEXT
-¦
-¦medium
+`topology.optimization`::
+*Type:* string +
+*Default:* none +
+*Valid Values:* [none, all] +
+*Importance:* medium +
++
+A configuration telling Kafka Streams if it should optimize the topology, disabled by default.
 
-¦`topology.optimization`
-a¦A configuration telling Kafka Streams if it should optimize the topology, disabled by default
-¦string
-¦none
-¦[none, all]
-¦medium
+`application.server`::
+*Type:* string +
+*Default:* "" +
+*Importance:* low +
++
+A host:port pair pointing to an embedded user defined endpoint that can be used for discovering the locations of state stores within a single KafkaStreams application.
 
-¦`application.server`
-a¦A host:port pair pointing to an embedded user defined endpoint that can be used for discovering the locations of state stores within a single KafkaStreams application
-¦string
-¦""
-¦
-¦low
+`buffered.records.per.partition`::
+*Type:* int +
+*Default:* 1000 +
+*Importance:* low +
++
+The maximum number of records to buffer per partition.
 
-¦`buffered.records.per.partition`
-a¦The maximum number of records to buffer per partition.
-¦int
-¦1000
-¦
-¦low
+`commit.interval.ms`::
+*Type:* long +
+*Default:* 30000 +
+*Importance:* low +
++
+The frequency with which to save the position of the processor. (Note, if 'processing.guarantee' is set to 'exactly_once', the default value is 100, otherwise the default value is 30000.
 
-¦`commit.interval.ms`
-a¦The frequency with which to save the position of the processor. (Note, if 'processing.guarantee' is set to 'exactly_once', the default value is 100, otherwise the default value is 30000.
-¦long
-¦30000
-¦
-¦low
+`connections.max.idle.ms`::
+*Type:* long +
+*Default:* 540000 +
+*Importance:* low +
++
+Close idle connections after the number of milliseconds specified by this config.
 
-¦`connections.max.idle.ms`
-a¦Close idle connections after the number of milliseconds specified by this config.
-¦long
-¦540000
-¦
-¦low
+`metadata.max.age.ms`::
+*Type:* long +
+*Default:* 300000 +
+*Valid Values:* [0,...] +
+*Importance:* low +
++
+The period of time in milliseconds after which we force a refresh of metadata even if we haven't seen any partition leadership changes to proactively discover any new brokers or partitions.
 
-¦`metadata.max.age.ms`
-a¦The period of time in milliseconds after which we force a refresh of metadata even if we haven't seen any partition leadership changes to proactively discover any new brokers or partitions.
-¦long
-¦300000
-¦[0,...]
-¦low
+`metric.reporters`::
+*Type:* list +
+*Default:* "" +
+*Importance:* low +
++
+A list of classes to use as metrics reporters. Implementing the `org.apache.kafka.common.metrics.MetricsReporter` interface allows plugging in classes that will be notified of new metric creation. The JmxReporter is always included to register JMX statistics.
 
-¦`metric.reporters`
-a¦A list of classes to use as metrics reporters. Implementing the `org.apache.kafka.common.metrics.MetricsReporter` interface allows plugging in classes that will be notified of new metric creation. The JmxReporter is always included to register JMX statistics.
-¦list
-¦""
-¦
-¦low
+`metrics.num.samples`::
+*Type:* int +
+*Default:* 2 +
+*Valid Values:* [1,...] +
+*Importance:* low +
++
+The number of samples maintained to compute metrics.
 
-¦`metrics.num.samples`
-a¦The number of samples maintained to compute metrics.
-¦int
-¦2
-¦[1,...]
-¦low
+`metrics.recording.level`::
+*Type:* string +
+*Default:* INFO +
+*Valid Values:* [INFO, DEBUG] +
+*Importance:* low +
++
+The highest recording level for metrics.
 
-¦`metrics.recording.level`
-a¦The highest recording level for metrics.
-¦string
-¦INFO
-¦[INFO, DEBUG]
-¦low
+`metrics.sample.window.ms`::
+*Type:* long +
+*Default:* 30000 +
+*Valid Values:* [0,...] +
+*Importance:* low +
++
+The window of time a metrics sample is computed over.
 
-¦`metrics.sample.window.ms`
-a¦The window of time a metrics sample is computed over.
-¦long
-¦30000
-¦[0,...]
-¦low
+`partition.grouper`::
+*Type:* class +
+*Default:* org.apache.kafka.streams.processor.DefaultPartitionGrouper +
+*Importance:* low +
++
+Partition grouper class that implements the `org.apache.kafka.streams.processor.PartitionGrouper` interface.
 
-¦`partition.grouper`
-a¦Partition grouper class that implements the `org.apache.kafka.streams.processor.PartitionGrouper` interface.
-¦class
-¦org.apache.kafka.streams.processor.DefaultPartitionGrouper
-¦
-¦low
+`poll.ms`::
+*Type:* long +
+*Default:* 100 +
+*Importance:* low +
++
+The amount of time in milliseconds to block waiting for input.
 
-¦`poll.ms`
-a¦The amount of time in milliseconds to block waiting for input.
-¦long
-¦100
-¦
-¦low
+`receive.buffer.bytes`::
+*Type:* int +
+*Default:* 32768 +
+*Valid Values:* [0,...] +
+*Importance:* low +
++
+The size of the TCP receive buffer (SO_RCVBUF) to use when reading data. If the value is -1, the OS default will be used.
 
-¦`receive.buffer.bytes`
-a¦The size of the TCP receive buffer (SO_RCVBUF) to use when reading data. If the value is -1, the OS default will be used.
-¦int
-¦32768
-¦[0,...]
-¦low
+`reconnect.backoff.max.ms`::
+*Type:* long +
+*Default:* 1000 +
+*Valid Values:* [0,...] +
+*Importance:* low +
++
+The maximum amount of time in milliseconds to wait when reconnecting to a broker that has repeatedly failed to connect. If provided, the backoff per host will increase exponentially for each consecutive connection failure, up to this maximum. After calculating the backoff increase, 20% random jitter is added to avoid connection storms.
 
-¦`reconnect.backoff.max.ms`
-a¦The maximum amount of time in milliseconds to wait when reconnecting to a broker that has repeatedly failed to connect. If provided, the backoff per host will increase exponentially for each consecutive connection failure, up to this maximum. After calculating the backoff increase, 20% random jitter is added to avoid connection storms.
-¦long
-¦1000
-¦[0,...]
-¦low
+`reconnect.backoff.ms`::
+*Type:* long +
+*Default:* 50 +
+*Valid Values:* [0,...] +
+*Importance:* low +
++
+The base amount of time to wait before attempting to reconnect to a given host. This avoids repeatedly connecting to a host in a tight loop. This backoff applies to all connection attempts by the client to a broker.
 
-¦`reconnect.backoff.ms`
-a¦The base amount of time to wait before attempting to reconnect to a given host. This avoids repeatedly connecting to a host in a tight loop. This backoff applies to all connection attempts by the client to a broker.
-¦long
-¦50
-¦[0,...]
-¦low
+`request.timeout.ms`::
+*Type:* int +
+*Default:* 40000 +
+*Valid Values:* [0,...] +
+*Importance:* low +
++
+The configuration controls the maximum amount of time the client will wait for the response of a request. If the response is not received before the timeout elapses the client will resend the request if necessary or fail the request if retries are exhausted.
 
-¦`request.timeout.ms`
-a¦The configuration controls the maximum amount of time the client will wait for the response of a request. If the response is not received before the timeout elapses the client will resend the request if necessary or fail the request if retries are exhausted.
-¦int
-¦40000
-¦[0,...]
-¦low
+`retries`::
+*Type:* int +
+*Default:* 0 +
+*Valid Values:* [0,...,2147483647] +
+*Importance:* low +
++
+Setting a value greater than zero will cause the client to resend any request that fails with a potentially transient error.
 
-¦`retries`
-a¦Setting a value greater than zero will cause the client to resend any request that fails with a potentially transient error.
-¦int
-¦0
-¦[0,...,2147483647]
-¦low
+`retry.backoff.ms`::
+*Type:* long +
+*Default:* 100 +
+*Valid Values:* [0,...] +
+*Importance:* low +
++
+The amount of time to wait before attempting to retry a failed request to a given topic partition. This avoids repeatedly sending requests in a tight loop under some failure scenarios.
 
-¦`retry.backoff.ms`
-a¦The amount of time to wait before attempting to retry a failed request to a given topic partition. This avoids repeatedly sending requests in a tight loop under some failure scenarios.
-¦long
-¦100
-¦[0,...]
-¦low
+`rocksdb.config.setter`::
+*Type:* class +
+*Default:* null +
+*Importance:* low +
++
+A Rocks DB config setter class or class name that implements the `org.apache.kafka.streams.state.RocksDBConfigSetter` interface.
 
-¦`rocksdb.config.setter`
-a¦A Rocks DB config setter class or class name that implements the `org.apache.kafka.streams.state.RocksDBConfigSetter` interface
-¦class
-¦null
-¦
-¦low
+`send.buffer.bytes`::
+*Type:* int +
+*Default:* 131072 +
+*Valid Values:* [0,...] +
+*Importance:* low +
++
+The size of the TCP send buffer (SO_SNDBUF) to use when sending data. If the value is -1, the OS default will be used.
 
-¦`send.buffer.bytes`
-a¦The size of the TCP send buffer (SO_SNDBUF) to use when sending data. If the value is -1, the OS default will be used.
-¦int
-¦131072
-¦[0,...]
-¦low
+`state.cleanup.delay.ms`::
+*Type:* long +
+*Default:* 600000 +
+*Importance:* low +
++
+The amount of time in milliseconds to wait before deleting state when a partition has migrated. Only state directories that have not been modified for at least state.cleanup.delay.ms will be removed.
 
-¦`state.cleanup.delay.ms`
-a¦The amount of time in milliseconds to wait before deleting state when a partition has migrated. Only state directories that have not been modified for at least state.cleanup.delay.ms will be removed
-¦long
-¦600000
-¦
-¦low
+`upgrade.from`::
+*Type:* string +
+*Default:* null +
+*Valid Values:* [null, 0.10.0, 0.10.1, 0.10.2, 0.11.0, 1.0, 1.1] +
+*Importance:* low +
++
+Allows upgrading from versions 0.10.0/0.10.1/0.10.2/0.11.0/1.0/1.1 to version 1.2 (or newer) in a backward compatible way. When upgrading from 1.2 to a newer version it is not required to specify this config.Default is null. Accepted values are "0.10.0", "0.10.1", "0.10.2", "0.11.0", "1.0", "1.1" (for upgrading from the corresponding old version).
 
-¦`upgrade.from`
-a¦Allows upgrading from versions 0.10.0/0.10.1/0.10.2/0.11.0/1.0/1.1 to version 1.2 (or newer) in a backward compatible way. When upgrading from 1.2 to a newer version it is not required to specify this config.Default is null. Accepted values are "0.10.0", "0.10.1", "0.10.2", "0.11.0", "1.0", "1.1" (for upgrading from the corresponding old version).
-¦string
-¦null
-¦[null, 0.10.0, 0.10.1, 0.10.2, 0.11.0, 1.0, 1.1]
-¦low
-
-¦`windowstore.changelog.additional.retention.ms`
-a¦Added to a windows maintainMs to ensure data is not deleted from the log prematurely. Allows for clock drift. Default is 1 day
-¦long
-¦86400000
-¦
-¦low
-
-|=====
+`windowstore.changelog.additional.retention.ms`::
+*Type:* long +
+*Default:* 86400000 +
+*Importance:* low +
++
+Added to a windows maintainMs to ensure data is not deleted from the log prematurely. Allows for clock drift. Default is 1 day.

--- a/books/ref-topic-config.adoc
+++ b/books/ref-topic-config.adoc
@@ -1,217 +1,234 @@
 // Module included in the following assemblies:
 //
 // assembly-overview.adoc
+//
+// THIS FILE IS AUTO-GENERATED. DO NOT EDIT BY HAND
+// Run "make clean buildall" to regenerate.
 
 [id='topic-configuration-parameters-{context}']
 = Topic configuration parameters
 
-[cols="7",options="header",separator=¦]
-|=====
-¦Name ¦Description ¦Type ¦Default ¦Valid Values ¦Server Default Property ¦Importance 
+`cleanup.policy`::
+*Type:* list +
+*Default:* delete +
+*Valid Values:* [compact, delete] +
+*Server Default Property:* log.cleanup.policy +
+*Importance:* medium +
++
+A string that is either "delete" or "compact". This string designates the retention policy to use on old log segments. The default policy ("delete") will discard old segments when their retention time or size limit has been reached. The "compact" setting will enable #compaction[log compaction] on the topic.
 
-¦`cleanup.policy`
-a¦A string that is either "delete" or "compact". This string designates the retention policy to use on old log segments. The default policy ("delete") will discard old segments when their retention time or size limit has been reached. The "compact" setting will enable #compaction[log compaction] on the topic.
-¦list
-¦delete
-¦[compact, delete]
-¦log.cleanup.policy
-¦medium
+`compression.type`::
+*Type:* string +
+*Default:* producer +
+*Valid Values:* [uncompressed, snappy, lz4, gzip, producer] +
+*Server Default Property:* compression.type +
+*Importance:* medium +
++
+Specify the final compression type for a given topic. This configuration accepts the standard compression codecs ('gzip', 'snappy', lz4). It additionally accepts 'uncompressed' which is equivalent to no compression; and 'producer' which means retain the original compression codec set by the producer.
 
-¦`compression.type`
-a¦Specify the final compression type for a given topic. This configuration accepts the standard compression codecs ('gzip', 'snappy', lz4). It additionally accepts 'uncompressed' which is equivalent to no compression; and 'producer' which means retain the original compression codec set by the producer.
-¦string
-¦producer
-¦[uncompressed, snappy, lz4, gzip, producer]
-¦compression.type
-¦medium
+`delete.retention.ms`::
+*Type:* long +
+*Default:* 86400000 +
+*Valid Values:* [0,...] +
+*Server Default Property:* log.cleaner.delete.retention.ms +
+*Importance:* medium +
++
+The amount of time to retain delete tombstone markers for #compaction[log compacted] topics. This setting also gives a bound on the time in which a consumer must complete a read if they begin from offset 0 to ensure that they get a valid snapshot of the final stage (otherwise delete tombstones may be collected before they complete their scan).
 
-¦`delete.retention.ms`
-a¦The amount of time to retain delete tombstone markers for #compaction[log compacted] topics. This setting also gives a bound on the time in which a consumer must complete a read if they begin from offset 0 to ensure that they get a valid snapshot of the final stage (otherwise delete tombstones may be collected before they complete their scan).
-¦long
-¦86400000
-¦[0,...]
-¦log.cleaner.delete.retention.ms
-¦medium
+`file.delete.delay.ms`::
+*Type:* long +
+*Default:* 60000 +
+*Valid Values:* [0,...] +
+*Server Default Property:* log.segment.delete.delay.ms +
+*Importance:* medium +
++
+The time to wait before deleting a file from the filesystem.
 
-¦`file.delete.delay.ms`
-a¦The time to wait before deleting a file from the filesystem
-¦long
-¦60000
-¦[0,...]
-¦log.segment.delete.delay.ms
-¦medium
+`flush.messages`::
+*Type:* long +
+*Default:* 9223372036854775807 +
+*Valid Values:* [0,...] +
+*Server Default Property:* log.flush.interval.messages +
+*Importance:* medium +
++
+This setting allows specifying an interval at which we will force an fsync of data written to the log. For example if this was set to 1 we would fsync after every message; if it were 5 we would fsync after every five messages. In general we recommend you not set this and use replication for durability and allow the operating system's background flush capabilities as it is more efficient. This setting can be overridden on a per-topic basis (see #topicconfigs[the per-topic configuration section]).
 
-¦`flush.messages`
-a¦This setting allows specifying an interval at which we will force an fsync of data written to the log. For example if this was set to 1 we would fsync after every message; if it were 5 we would fsync after every five messages. In general we recommend you not set this and use replication for durability and allow the operating system's background flush capabilities as it is more efficient. This setting can be overridden on a per-topic basis (see #topicconfigs[the per-topic configuration section]).
-¦long
-¦9223372036854775807
-¦[0,...]
-¦log.flush.interval.messages
-¦medium
+`flush.ms`::
+*Type:* long +
+*Default:* 9223372036854775807 +
+*Valid Values:* [0,...] +
+*Server Default Property:* log.flush.interval.ms +
+*Importance:* medium +
++
+This setting allows specifying a time interval at which we will force an fsync of data written to the log. For example if this was set to 1000 we would fsync after 1000 ms had passed. In general we recommend you not set this and use replication for durability and allow the operating system's background flush capabilities as it is more efficient.
 
-¦`flush.ms`
-a¦This setting allows specifying a time interval at which we will force an fsync of data written to the log. For example if this was set to 1000 we would fsync after 1000 ms had passed. In general we recommend you not set this and use replication for durability and allow the operating system's background flush capabilities as it is more efficient.
-¦long
-¦9223372036854775807
-¦[0,...]
-¦log.flush.interval.ms
-¦medium
+`follower.replication.throttled.replicas`::
+*Type:* list +
+*Default:* "" +
+*Valid Values:* [partitionId],[brokerId]:[partitionId],[brokerId]:... +
+*Server Default Property:* follower.replication.throttled.replicas +
+*Importance:* medium +
++
+A list of replicas for which log replication should be throttled on the follower side. The list should describe a set of replicas in the form [PartitionId]:[BrokerId],[PartitionId]:[BrokerId]:... or alternatively the wildcard '*' can be used to throttle all replicas for this topic.
 
-¦`follower.replication.throttled.replicas`
-a¦A list of replicas for which log replication should be throttled on the follower side. The list should describe a set of replicas in the form [PartitionId]:[BrokerId],[PartitionId]:[BrokerId]:... or alternatively the wildcard '*' can be used to throttle all replicas for this topic.
-¦list
-¦""
-¦[partitionId],[brokerId]:[partitionId],[brokerId]:...
-¦follower.replication.throttled.replicas
-¦medium
+`index.interval.bytes`::
+*Type:* int +
+*Default:* 4096 +
+*Valid Values:* [0,...] +
+*Server Default Property:* log.index.interval.bytes +
+*Importance:* medium +
++
+This setting controls how frequently Kafka adds an index entry to it's offset index. The default setting ensures that we index a message roughly every 4096 bytes. More indexing allows reads to jump closer to the exact position in the log but makes the index larger. You probably don't need to change this.
 
-¦`index.interval.bytes`
-a¦This setting controls how frequently Kafka adds an index entry to it's offset index. The default setting ensures that we index a message roughly every 4096 bytes. More indexing allows reads to jump closer to the exact position in the log but makes the index larger. You probably don't need to change this.
-¦int
-¦4096
-¦[0,...]
-¦log.index.interval.bytes
-¦medium
+`leader.replication.throttled.replicas`::
+*Type:* list +
+*Default:* "" +
+*Valid Values:* [partitionId],[brokerId]:[partitionId],[brokerId]:... +
+*Server Default Property:* leader.replication.throttled.replicas +
+*Importance:* medium +
++
+A list of replicas for which log replication should be throttled on the leader side. The list should describe a set of replicas in the form [PartitionId]:[BrokerId],[PartitionId]:[BrokerId]:... or alternatively the wildcard '*' can be used to throttle all replicas for this topic.
 
-¦`leader.replication.throttled.replicas`
-a¦A list of replicas for which log replication should be throttled on the leader side. The list should describe a set of replicas in the form [PartitionId]:[BrokerId],[PartitionId]:[BrokerId]:... or alternatively the wildcard '*' can be used to throttle all replicas for this topic.
-¦list
-¦""
-¦[partitionId],[brokerId]:[partitionId],[brokerId]:...
-¦leader.replication.throttled.replicas
-¦medium
+`max.message.bytes`::
+*Type:* int +
+*Default:* 1000012 +
+*Valid Values:* [0,...] +
+*Server Default Property:* message.max.bytes +
+*Importance:* medium +
++
 
-¦`max.message.bytes`
-a¦
++
 The largest record batch size allowed by Kafka. If this is increased and there are consumers older than 0.10.2, the consumers' fetch size must also be increased so that the they can fetch record batches this large.
-
++
 In the latest message format version, records are always grouped into batches for efficiency. In previous message format versions, uncompressed records are not grouped into batches and this limit only applies to a single record in that case.
 
-¦int
-¦1000012
-¦[0,...]
-¦message.max.bytes
-¦medium
 
-¦`message.format.version`
-a¦Specify the message format version the broker will use to append messages to the logs. The value should be a valid ApiVersion. Some examples are: 0.8.2, 0.9.0.0, 0.10.0, check ApiVersion for more details. By setting a particular message format version, the user is certifying that all the existing messages on disk are smaller or equal than the specified version. Setting this value incorrectly will cause consumers with older versions to break as they will receive messages with a format that they don't understand.
-¦string
-¦2.0-IV1
-¦
-¦log.message.format.version
-¦medium
+`message.format.version`::
+*Type:* string +
+*Default:* 2.0-IV1 +
+*Server Default Property:* log.message.format.version +
+*Importance:* medium +
++
+Specify the message format version the broker will use to append messages to the logs. The value should be a valid ApiVersion. Some examples are: 0.8.2, 0.9.0.0, 0.10.0, check ApiVersion for more details. By setting a particular message format version, the user is certifying that all the existing messages on disk are smaller or equal than the specified version. Setting this value incorrectly will cause consumers with older versions to break as they will receive messages with a format that they don't understand.
 
-¦`message.timestamp.difference.max.ms`
-a¦The maximum difference allowed between the timestamp when a broker receives a message and the timestamp specified in the message. If message.timestamp.type=CreateTime, a message will be rejected if the difference in timestamp exceeds this threshold. This configuration is ignored if message.timestamp.type=LogAppendTime.
-¦long
-¦9223372036854775807
-¦[0,...]
-¦log.message.timestamp.difference.max.ms
-¦medium
+`message.timestamp.difference.max.ms`::
+*Type:* long +
+*Default:* 9223372036854775807 +
+*Valid Values:* [0,...] +
+*Server Default Property:* log.message.timestamp.difference.max.ms +
+*Importance:* medium +
++
+The maximum difference allowed between the timestamp when a broker receives a message and the timestamp specified in the message. If message.timestamp.type=CreateTime, a message will be rejected if the difference in timestamp exceeds this threshold. This configuration is ignored if message.timestamp.type=LogAppendTime.
 
-¦`message.timestamp.type`
-a¦Define whether the timestamp in the message is message create time or log append time. The value should be either `CreateTime` or `LogAppendTime`
-¦string
-¦CreateTime
-¦[CreateTime, LogAppendTime]
-¦log.message.timestamp.type
-¦medium
+`message.timestamp.type`::
+*Type:* string +
+*Default:* CreateTime +
+*Valid Values:* [CreateTime, LogAppendTime] +
+*Server Default Property:* log.message.timestamp.type +
+*Importance:* medium +
++
+Define whether the timestamp in the message is message create time or log append time. The value should be either `CreateTime` or `LogAppendTime`.
 
-¦`min.cleanable.dirty.ratio`
-a¦This configuration controls how frequently the log compactor will attempt to clean the log (assuming #compaction[log compaction] is enabled). By default we will avoid cleaning a log where more than 50% of the log has been compacted. This ratio bounds the maximum space wasted in the log by duplicates (at 50% at most 50% of the log could be duplicates). A higher ratio will mean fewer, more efficient cleanings but will mean more wasted space in the log.
-¦double
-¦0.5
-¦[0,...,1]
-¦log.cleaner.min.cleanable.ratio
-¦medium
+`min.cleanable.dirty.ratio`::
+*Type:* double +
+*Default:* 0.5 +
+*Valid Values:* [0,...,1] +
+*Server Default Property:* log.cleaner.min.cleanable.ratio +
+*Importance:* medium +
++
+This configuration controls how frequently the log compactor will attempt to clean the log (assuming #compaction[log compaction] is enabled). By default we will avoid cleaning a log where more than 50% of the log has been compacted. This ratio bounds the maximum space wasted in the log by duplicates (at 50% at most 50% of the log could be duplicates). A higher ratio will mean fewer, more efficient cleanings but will mean more wasted space in the log.
 
-¦`min.compaction.lag.ms`
-a¦The minimum time a message will remain uncompacted in the log. Only applicable for logs that are being compacted.
-¦long
-¦0
-¦[0,...]
-¦log.cleaner.min.compaction.lag.ms
-¦medium
+`min.compaction.lag.ms`::
+*Type:* long +
+*Default:* 0 +
+*Valid Values:* [0,...] +
+*Server Default Property:* log.cleaner.min.compaction.lag.ms +
+*Importance:* medium +
++
+The minimum time a message will remain uncompacted in the log. Only applicable for logs that are being compacted.
 
-¦`min.insync.replicas`
-a¦When a producer sets acks to "all" (or "-1"), this configuration specifies the minimum number of replicas that must acknowledge a write for the write to be considered successful. If this minimum cannot be met, then the producer will raise an exception (either NotEnoughReplicas or NotEnoughReplicasAfterAppend).
+`min.insync.replicas`::
+*Type:* int +
+*Default:* 1 +
+*Valid Values:* [1,...] +
+*Server Default Property:* min.insync.replicas +
+*Importance:* medium +
++
+When a producer sets acks to "all" (or "-1"), this configuration specifies the minimum number of replicas that must acknowledge a write for the write to be considered successful. If this minimum cannot be met, then the producer will raise an exception (either NotEnoughReplicas or NotEnoughReplicasAfterAppend).
 When used together, min.insync.replicas and acks allow you to enforce greater durability guarantees. A typical scenario would be to create a topic with a replication factor of 3, set min.insync.replicas to 2, and produce with acks of "all". This will ensure that the producer raises an exception if a majority of replicas do not receive a write.
-¦int
-¦1
-¦[1,...]
-¦min.insync.replicas
-¦medium
 
-¦`preallocate`
-a¦True if we should preallocate the file on disk when creating a new log segment.
-¦boolean
-¦false
-¦
-¦log.preallocate
-¦medium
+`preallocate`::
+*Type:* boolean +
+*Default:* false +
+*Server Default Property:* log.preallocate +
+*Importance:* medium +
++
+True if we should preallocate the file on disk when creating a new log segment.
 
-¦`retention.bytes`
-a¦This configuration controls the maximum size a partition (which consists of log segments) can grow to before we will discard old log segments to free up space if we are using the "delete" retention policy. By default there is no size limit only a time limit. Since this limit is enforced at the partition level, multiply it by the number of partitions to compute the topic retention in bytes.
-¦long
-¦-1
-¦
-¦log.retention.bytes
-¦medium
+`retention.bytes`::
+*Type:* long +
+*Default:* -1 +
+*Server Default Property:* log.retention.bytes +
+*Importance:* medium +
++
+This configuration controls the maximum size a partition (which consists of log segments) can grow to before we will discard old log segments to free up space if we are using the "delete" retention policy. By default there is no size limit only a time limit. Since this limit is enforced at the partition level, multiply it by the number of partitions to compute the topic retention in bytes.
 
-¦`retention.ms`
-a¦This configuration controls the maximum time we will retain a log before we will discard old log segments to free up space if we are using the "delete" retention policy. This represents an SLA on how soon consumers must read their data. If set to -1, no time limit is applied.
-¦long
-¦604800000
-¦
-¦log.retention.ms
-¦medium
+`retention.ms`::
+*Type:* long +
+*Default:* 604800000 +
+*Server Default Property:* log.retention.ms +
+*Importance:* medium +
++
+This configuration controls the maximum time we will retain a log before we will discard old log segments to free up space if we are using the "delete" retention policy. This represents an SLA on how soon consumers must read their data. If set to -1, no time limit is applied.
 
-¦`segment.bytes`
-a¦This configuration controls the segment file size for the log. Retention and cleaning is always done a file at a time so a larger segment size means fewer files but less granular control over retention.
-¦int
-¦1073741824
-¦[14,...]
-¦log.segment.bytes
-¦medium
+`segment.bytes`::
+*Type:* int +
+*Default:* 1073741824 +
+*Valid Values:* [14,...] +
+*Server Default Property:* log.segment.bytes +
+*Importance:* medium +
++
+This configuration controls the segment file size for the log. Retention and cleaning is always done a file at a time so a larger segment size means fewer files but less granular control over retention.
 
-¦`segment.index.bytes`
-a¦This configuration controls the size of the index that maps offsets to file positions. We preallocate this index file and shrink it only after log rolls. You generally should not need to change this setting.
-¦int
-¦10485760
-¦[0,...]
-¦log.index.size.max.bytes
-¦medium
+`segment.index.bytes`::
+*Type:* int +
+*Default:* 10485760 +
+*Valid Values:* [0,...] +
+*Server Default Property:* log.index.size.max.bytes +
+*Importance:* medium +
++
+This configuration controls the size of the index that maps offsets to file positions. We preallocate this index file and shrink it only after log rolls. You generally should not need to change this setting.
 
-¦`segment.jitter.ms`
-a¦The maximum random jitter subtracted from the scheduled segment roll time to avoid thundering herds of segment rolling
-¦long
-¦0
-¦[0,...]
-¦log.roll.jitter.ms
-¦medium
+`segment.jitter.ms`::
+*Type:* long +
+*Default:* 0 +
+*Valid Values:* [0,...] +
+*Server Default Property:* log.roll.jitter.ms +
+*Importance:* medium +
++
+The maximum random jitter subtracted from the scheduled segment roll time to avoid thundering herds of segment rolling.
 
-¦`segment.ms`
-a¦This configuration controls the period of time after which Kafka will force the log to roll even if the segment file isn't full to ensure that retention can delete or compact old data.
-¦long
-¦604800000
-¦[1,...]
-¦log.roll.ms
-¦medium
+`segment.ms`::
+*Type:* long +
+*Default:* 604800000 +
+*Valid Values:* [1,...] +
+*Server Default Property:* log.roll.ms +
+*Importance:* medium +
++
+This configuration controls the period of time after which Kafka will force the log to roll even if the segment file isn't full to ensure that retention can delete or compact old data.
 
-¦`unclean.leader.election.enable`
-a¦Indicates whether to enable replicas not in the ISR set to be elected as leader as a last resort, even though doing so may result in data loss.
-¦boolean
-¦false
-¦
-¦unclean.leader.election.enable
-¦medium
+`unclean.leader.election.enable`::
+*Type:* boolean +
+*Default:* false +
+*Server Default Property:* unclean.leader.election.enable +
+*Importance:* medium +
++
+Indicates whether to enable replicas not in the ISR set to be elected as leader as a last resort, even though doing so may result in data loss.
 
-¦`message.downconversion.enable`
-a¦This configuration controls whether down-conversion of message formats is enabled to satisfy consume requests. When set to `false`, broker will not perform down-conversion for consumers expecting an older message format. The broker responds with `UNSUPPORTED_VERSION` error for consume requests from such older clients. This configurationdoes not apply to any message format conversion that might be required for replication to followers.
-¦boolean
-¦true
-¦
-¦log.message.downconversion.enable
-¦low
-
-|=====
+`message.downconversion.enable`::
+*Type:* boolean +
+*Default:* true +
+*Server Default Property:* log.message.downconversion.enable +
+*Importance:* low +
++
+This configuration controls whether down-conversion of message formats is enabled to satisfy consume requests. When set to `false`, broker will not perform down-conversion for consumers expecting an older message format. The broker responds with `UNSUPPORTED_VERSION` error for consume requests from such older clients. This configurationdoes not apply to any message format conversion that might be required for replication to followers.

--- a/generator/Makefile
+++ b/generator/Makefile
@@ -3,6 +3,8 @@ CONFIG_DOCS=ref-broker-config.adoc ref-consumer-config.adoc ref-producer-config.
 METRICS_DOCS=ref-mbeans-producer-gen.adoc ref-mbeans-consumer-gen.adoc ref-mbeans-kafka-connect-gen.adoc ref-mbeans-kafka-streams-gen.adoc
 JAVA_FILES:=$(shell find src/main/java/ -type f -name '*.java')
 
+buildall: docs
+
 docs: configs metrics
 
 clean:
@@ -50,4 +52,4 @@ ref-mbeans-kafka-streams-gen.adoc: metrics.sh $(TOOL)
 
 metrics: $(METRICS_DOCS)
 
-.PHONY: docs clean configs metrics 
+.PHONY: buildall docs clean configs metrics 

--- a/generator/configs.sh
+++ b/generator/configs.sh
@@ -12,6 +12,9 @@ cat <<EOF
 // Module included in the following assemblies:
 //
 // assembly-overview.adoc
+//
+// THIS FILE IS AUTO-GENERATED. DO NOT EDIT BY HAND
+// Run "make clean buildall" to regenerate.
 
 [id='$DOC_ID-{context}']
 = ${TITLE}


### PR DESCRIPTION
* The table didn't cope well with narrow widths, so use a definition list
* Also add support for dynamic update field for broker configs
* Add missing full stops in descriptions which lacked them
* Include comment in generate docs to alert authors not to change