### PR TITLE
Bump the Red Hat serial number for Maven dependencies

### DIFF
--- a/books/common/attributes.adoc
+++ b/books/common/attributes.adoc
@@ -27,7 +27,7 @@
 
 // Maven dependencies
 :MavenRepo: https://maven.repository.redhat.com/ga/
-:ArtifactVersion: 2.1.1.redhat-00001
+:ArtifactVersion: 2.1.1.redhat-00002
 
 // File locations
 :UpstreamDir: upstream/documentation/book


### PR DESCRIPTION
Unfortunately I had to do Kafka re-build which increases the Red Hat suffix. This PR should adapt the docs accordingly.