### PR TITLE
Added books/build/** to the gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ out
 books/master.html
 Makefile.publish
 html/
-
+books/build/**


### PR DESCRIPTION
This pull request adds the `books/build/**` directory to the .gitignore file. This means that writers can build the output using ccutil without hundreds of build files being flagged as modified in their local repository.