### PR TITLE
[DOC] Add new section on Kafka Bridge

### DIFF
--- a/books/con-kafka-commit-log-configuration.adoc
+++ b/books/con-kafka-commit-log-configuration.adoc
@@ -7,12 +7,12 @@
 = Commit logs
 
 Apache Kafka stores all records it receives from producers in commit logs.
-The commit logs contain the actual data, in the form of records, that Kafka needs to deliver. 
+The commit logs contain the actual data, in the form of records, that Kafka needs to deliver.
 These are not the application log files which record what the broker is doing.
 
 .Log directories
 
-You can configure log directories using the `log.dirs` property filed to store commit logs in one or multiple log directories.
+You can configure log directories using the `log.dirs` property files to store commit logs in one or multiple log directories.
 It should be set to `/var/lib/kafka` directory created during installation:
 
 [source]

--- a/books/con-kafka-commit-log-configuration.adoc
+++ b/books/con-kafka-commit-log-configuration.adoc
@@ -12,7 +12,7 @@ These are not the application log files which record what the broker is doing.
 
 .Log directories
 
-You can configure log directories using the `log.dirs` property files to store commit logs in one or multiple log directories.
+You can configure log directories using the `log.dirs` property file to store commit logs in one or multiple log directories.
 It should be set to `/var/lib/kafka` directory created during installation:
 
 [source]

--- a/books/con-overview-of-kafka-bridge.adoc
+++ b/books/con-overview-of-kafka-bridge.adoc
@@ -7,11 +7,7 @@
 
 The {ProductName} Kafka Bridge provides an API for integrating HTTP-based clients with a Kafka cluster running on {ProductPlatformName}. The API enables these clients to produce and consume messages without the requirement to use the native Kafka protocol.
 
-<<<<<<< HEAD
 The API has two main resources -- `consumers` and `topics` -- that are exposed and made accessible through endpoints to interact with consumers and producers in your Kafka cluster. The resources relate only to the Kafka Bridge, not the consumers and producers connected directly to Kafka.
-=======
-The API has two main resources -- `consumers` and `topics` -- that are exposed and made accessible through endpoints to interact with consumers and producers in your Kafka cluster. The resources relate only to the Kafka Bridge, not the consumers and producers connected directly to Kafka. 
->>>>>>> review edits js
 
 You can:
 

--- a/books/con-overview-of-kafka-bridge.adoc
+++ b/books/con-overview-of-kafka-bridge.adoc
@@ -7,7 +7,11 @@
 
 The {ProductName} Kafka Bridge provides an API for integrating HTTP-based clients with a Kafka cluster running on {ProductPlatformName}. The API enables these clients to produce and consume messages without the requirement to use the native Kafka protocol.
 
+<<<<<<< HEAD
 The API has two main resources -- `consumers` and `topics` -- that are exposed and made accessible through endpoints to interact with consumers and producers in your Kafka cluster. The resources relate only to the Kafka Bridge, not the consumers and producers connected directly to Kafka.
+=======
+The API has two main resources -- `consumers` and `topics` -- that are exposed and made accessible through endpoints to interact with consumers and producers in your Kafka cluster. The resources relate only to the Kafka Bridge, not the consumers and producers connected directly to Kafka. 
+>>>>>>> review edits js
 
 You can:
 

--- a/books/con-overview-of-kafka-bridge.adoc
+++ b/books/con-overview-of-kafka-bridge.adoc
@@ -7,7 +7,7 @@
 
 The {ProductName} Kafka Bridge provides an API for integrating HTTP-based clients with a Kafka cluster running on {ProductPlatformName}. The API enables these clients to produce and consume messages without the requirement to use the native Kafka protocol.
 
-The API has two main resources -- `consumers` and `topics` -- that are exposed and made accessible through endpoints to interact with consumers and producers in your Kafka cluster. The resources relate only to the Kafka Bridge, not the consumers and producers connected directly to Kafka. 
+The API has two main resources -- `consumers` and `topics` -- that are exposed and made accessible through endpoints to interact with consumers and producers in your Kafka cluster. The resources relate only to the Kafka Bridge, not the consumers and producers connected directly to Kafka.
 
 You can:
 

--- a/books/con-requests-kafka-bridge.adoc
+++ b/books/con-requests-kafka-bridge.adoc
@@ -15,7 +15,13 @@ Authentication and encryption between HTTP clients and the Kafka Bridge is not y
 
 You can configure xref:assembly-kafka-encryption-and-authentication-{context}[TLS or SASL-based authentication] between the Kafka Bridge and your Kafka cluster.
 
+<<<<<<< HEAD
 You configure the Kafka Bridge for authentication through its xref:proc-configuring-kafka-bridge-{context}[properties file].
+=======
+You configure the Kafka Bridge as any other Kafka client, prefixing the Kafka consumer/producer options with `kafka`.
+
+For more information, see xref:assembly-kafka-encryption-and-authentication-{context}[].
+>>>>>>> review edits js
 
 == Data formats and headers
 

--- a/books/con-requests-kafka-bridge.adoc
+++ b/books/con-requests-kafka-bridge.adoc
@@ -15,13 +15,7 @@ Authentication and encryption between HTTP clients and the Kafka Bridge is not y
 
 You can configure xref:assembly-kafka-encryption-and-authentication-{context}[TLS or SASL-based authentication] between the Kafka Bridge and your Kafka cluster.
 
-<<<<<<< HEAD
 You configure the Kafka Bridge for authentication through its xref:proc-configuring-kafka-bridge-{context}[properties file].
-=======
-You configure the Kafka Bridge as any other Kafka client, prefixing the Kafka consumer/producer options with `kafka`.
-
-For more information, see xref:assembly-kafka-encryption-and-authentication-{context}[].
->>>>>>> review edits js
 
 == Data formats and headers
 


### PR DESCRIPTION
The PR includes new content created for the download, deployment and configuration of the installation archive for the Kafka Bridge on RHEL.

This has been added along with the concepts Daniel has created for the Kafka Bridge on OCP.

Work in progress. Some of the content created for OCP may not be relevant here. As the OCP content changes, the changes should be reflected in the same sections here.