### PR TITLE
Use KAFKA_OPTS instead of EXTRA_ARGS for Zookeeper SASL configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ books/master.html
 Makefile.publish
 html/
 books/build/**
+
+# MacOS custom attributes internal file
+.DS_Store

--- a/books/con-zookeeper-sasl-authentication.adoc
+++ b/books/con-zookeeper-sasl-authentication.adoc
@@ -64,12 +64,12 @@ quorum.auth.server.loginContext=QuorumServer
 quorum.cnxn.threads.size=20
 ----
 
-Use the `EXTRA_ARGS` environment variable to pass the JAAS configuration file to the Zookeeper server as a Java property:
+Use the `KAFKA_OPTS` environment variable to pass the JAAS configuration file to the Zookeeper server as a Java property:
 
 [source]
 ----
 su - kafka
-export EXTRA_ARGS="-Djava.security.auth.login.config=/opt/kafka/config/zookeeper-jaas.conf"; /opt/kafka/bin/zookeeper-server-start.sh -daemon /opt/kafka/config/zookeeper.properties
+export KAFKA_OPTS="-Djava.security.auth.login.config=/opt/kafka/config/zookeeper-jaas.conf"; /opt/kafka/bin/zookeeper-server-start.sh -daemon /opt/kafka/config/zookeeper.properties
 ----
 
 For more information about server-to-server authentication, see
@@ -107,12 +107,12 @@ authProvider.3=org.apache.zookeeper.server.auth.SASLAuthenticationProvider
 
 You must add the `authProvider._<ID>_` property for every server that is part of the Zookeeper cluster.
 
-Use the `EXTRA_ARGS` environment variable to pass the JAAS configuration file to the Zookeeper server as a Java property:
+Use the `KAFKA_OPTS` environment variable to pass the JAAS configuration file to the Zookeeper server as a Java property:
 
 [source]
 ----
 su - kafka
-export EXTRA_ARGS="-Djava.security.auth.login.config=/opt/kafka/config/zookeeper-jaas.conf"; /opt/kafka/bin/zookeeper-server-start.sh -daemon /opt/kafka/config/zookeeper.properties
+export KAFKA_OPTS="-Djava.security.auth.login.config=/opt/kafka/config/zookeeper-jaas.conf"; /opt/kafka/bin/zookeeper-server-start.sh -daemon /opt/kafka/config/zookeeper.properties
 ----
 
 For more information about configuring Zookeeper authentication in Kafka brokers, see xref:assembly-kafka-zookeeper-authentication-{context}[].

--- a/books/proc-zookeeper-enable-client-to-server-auth-digest-md5.adoc
+++ b/books/proc-zookeeper-enable-client-to-server-auth-digest-md5.adoc
@@ -64,12 +64,12 @@ authProvider.3=org.apache.zookeeper.server.auth.SASLAuthenticationProvider
 ----
 
 . Restart all Zookeeper nodes one by one.
-To pass the JAAS configuration to Zookeeper, use the `EXTRA_ARGS` environment variable.
+To pass the JAAS configuration to Zookeeper, use the `KAFKA_OPTS` environment variable.
 +
 [source]
 ----
 su - kafka
-export EXTRA_ARGS="-Djava.security.auth.login.config=/opt/kafka/config/zookeeper-jaas.conf"; /opt/kafka/bin/zookeeper-server-start.sh -daemon /opt/kafka/config/zookeeper.properties
+export KAFKA_OPTS="-Djava.security.auth.login.config=/opt/kafka/config/zookeeper-jaas.conf"; /opt/kafka/bin/zookeeper-server-start.sh -daemon /opt/kafka/config/zookeeper.properties
 ----
 
 .Additional resources

--- a/books/proc-zookeeper-enable-server-to-server-auth-digest-md5.adoc
+++ b/books/proc-zookeeper-enable-server-to-server-auth-digest-md5.adoc
@@ -61,12 +61,12 @@ quorum.cnxn.threads.size=20
 ----
 
 . Restart all Zookeeper nodes one by one.
-To pass the JAAS configuration to Zookeeper, use the `EXTRA_ARGS` environment variable.
+To pass the JAAS configuration to Zookeeper, use the `KAFKA_OPTS` environment variable.
 +
 [source]
 ----
 su - kafka
-export EXTRA_ARGS="-Djava.security.auth.login.config=/opt/kafka/config/zookeeper-jaas.conf"; /opt/kafka/bin/zookeeper-server-start.sh -daemon /opt/kafka/config/zookeeper.properties
+export KAFKA_OPTS="-Djava.security.auth.login.config=/opt/kafka/config/zookeeper-jaas.conf"; /opt/kafka/bin/zookeeper-server-start.sh -daemon /opt/kafka/config/zookeeper.properties
 ----
 
 .Additional resources


### PR DESCRIPTION
It seems the `$EXTRA_ARGS` doesn't work anymore for configuring JAAS part of Zookeeper SASL configuration. The following command from out docs `$ export EXTRA_ARGS="-Djava.security.auth.login.config=/opt/kafka/config/zookeeper-jaas.conf"; /opt/kafka/bin/zookeeper-server-start.sh -daemon /opt/kafka/config/zookeeper.properties` seems to throw error `/opt/kafka/bin/kafka-run-class.sh: line 304: : No such file or directory`.

The solutions seems to be to use `$KAFKA_OPTS` instead.