### PR TITLE
Make ZooKeeper references consistent

### DIFF
--- a/books/assembly-configuring-zookeeper-authentication.adoc
+++ b/books/assembly-configuring-zookeeper-authentication.adoc
@@ -6,9 +6,9 @@
 
 = Authentication
 
-By default, {Zookeeper} does not use any form of authentication and allows anonymous connections.
+By default, ZooKeeper does not use any form of authentication and allows anonymous connections.
 However, it supports Java Authentication and Authorization Service (JAAS) which can be used to set up  authentication using Simple Authentication and Security Layer (SASL).
-{Zookeeper} supports authentication using the DIGEST-MD5 SASL mechanism with locally stored credentials.
+ZooKeeper supports authentication using the DIGEST-MD5 SASL mechanism with locally stored credentials.
 
 include::con-zookeeper-sasl-authentication.adoc[leveloffset=+1]
 

--- a/books/assembly-configuring-zookeeper-authentication.adoc
+++ b/books/assembly-configuring-zookeeper-authentication.adoc
@@ -6,9 +6,9 @@
 
 = Authentication
 
-By default, Zookeeper does not use any form of authentication and allows anonymous connections.
+By default, {Zookeeper} does not use any form of authentication and allows anonymous connections.
 However, it supports Java Authentication and Authorization Service (JAAS) which can be used to set up  authentication using Simple Authentication and Security Layer (SASL).
-Zookeeper supports authentication using the DIGEST-MD5 SASL mechanism with locally stored credentials.
+{Zookeeper} supports authentication using the DIGEST-MD5 SASL mechanism with locally stored credentials.
 
 include::con-zookeeper-sasl-authentication.adoc[leveloffset=+1]
 

--- a/books/assembly-configuring-zookeeper.adoc
+++ b/books/assembly-configuring-zookeeper.adoc
@@ -1,7 +1,7 @@
-= Configuring {Zookeeper}
+= Configuring ZooKeeper
 
-Kafka uses {Zookeeper} to store configuration data and for cluster coordination.
-It is strongly recommended to run a cluster of replicated {Zookeeper} instances.
+Kafka uses ZooKeeper to store configuration data and for cluster coordination.
+It is strongly recommended to run a cluster of replicated ZooKeeper instances.
 
 include::con-zookeeper-basic-configuration.adoc[leveloffset=+1]
 

--- a/books/assembly-configuring-zookeeper.adoc
+++ b/books/assembly-configuring-zookeeper.adoc
@@ -1,7 +1,7 @@
-= Configuring Zookeeper
+= Configuring {Zookeeper}
 
-Kafka uses Zookeeper to store configuration data and for cluster coordination.
-It is strongly recommended to run a cluster of replicated Zookeeper instances.
+Kafka uses {Zookeeper} to store configuration data and for cluster coordination.
+It is strongly recommended to run a cluster of replicated {Zookeeper} instances.
 
 include::con-zookeeper-basic-configuration.adoc[leveloffset=+1]
 

--- a/books/assembly-getting-started.adoc
+++ b/books/assembly-getting-started.adoc
@@ -11,7 +11,7 @@
 AMQ Streams is distributed as single ZIP file.
 This ZIP file contains AMQ Streams components:
 
-* Apache Zookeeper
+* Apache {Zookeeper}
 * Apache Kafka
 * Apache Kafka Connect
 * Apache Kafka Mirror Maker

--- a/books/assembly-getting-started.adoc
+++ b/books/assembly-getting-started.adoc
@@ -11,7 +11,7 @@
 AMQ Streams is distributed as single ZIP file.
 This ZIP file contains AMQ Streams components:
 
-* Apache {Zookeeper}
+* Apache ZooKeeper
 * Apache Kafka
 * Apache Kafka Connect
 * Apache Kafka Mirror Maker

--- a/books/assembly-kafka-zookeeper-authentication.adoc
+++ b/books/assembly-kafka-zookeeper-authentication.adoc
@@ -4,11 +4,11 @@
 
 [id='assembly-kafka-zookeeper-authentication-{context}']
 
-= Zookeeper authentication
+= {Zookeeper} authentication
 
-By default, connections between Zookeeper and Kafka are not authenticated.
-However, Kafka and Zookeeper support Java Authentication and Authorization Service (JAAS) which can be used to set up authentication using Simple Authentication and Security Layer (SASL).
-Zookeeper supports authentication using the DIGEST-MD5 SASL mechanism with locally stored credentials.
+By default, connections between {Zookeeper} and Kafka are not authenticated.
+However, Kafka and {Zookeeper} support Java Authentication and Authorization Service (JAAS) which can be used to set up authentication using Simple Authentication and Security Layer (SASL).
+{Zookeeper} supports authentication using the DIGEST-MD5 SASL mechanism with locally stored credentials.
 
 include::con-kafka-zookeeper-authentication-jaas.adoc[leveloffset=+1]
 

--- a/books/assembly-kafka-zookeeper-authentication.adoc
+++ b/books/assembly-kafka-zookeeper-authentication.adoc
@@ -4,11 +4,11 @@
 
 [id='assembly-kafka-zookeeper-authentication-{context}']
 
-= {Zookeeper} authentication
+= ZooKeeper authentication
 
-By default, connections between {Zookeeper} and Kafka are not authenticated.
-However, Kafka and {Zookeeper} support Java Authentication and Authorization Service (JAAS) which can be used to set up authentication using Simple Authentication and Security Layer (SASL).
-{Zookeeper} supports authentication using the DIGEST-MD5 SASL mechanism with locally stored credentials.
+By default, connections between ZooKeeper and Kafka are not authenticated.
+However, Kafka and ZooKeeper support Java Authentication and Authorization Service (JAAS) which can be used to set up authentication using Simple Authentication and Security Layer (SASL).
+ZooKeeper supports authentication using the DIGEST-MD5 SASL mechanism with locally stored credentials.
 
 include::con-kafka-zookeeper-authentication-jaas.adoc[leveloffset=+1]
 

--- a/books/assembly-kafka-zookeeper-authorization.adoc
+++ b/books/assembly-kafka-zookeeper-authorization.adoc
@@ -4,9 +4,9 @@
 
 [id='assembly-kafka-zookeeper-authorization-{context}']
 
-= {Zookeeper} authorization
+= ZooKeeper authorization
 
-When authentication is enabled between Kafka and {Zookeeper}, you can use {Zookeeper} Access Control List (ACL) rules to automatically control access to Kafka's metadata stored in {Zookeeper}.
+When authentication is enabled between Kafka and ZooKeeper, you can use ZooKeeper Access Control List (ACL) rules to automatically control access to Kafka's metadata stored in ZooKeeper.
 
 include::con-kafka-zookeeper-authorization-enabling-acls.adoc[leveloffset=+1]
 

--- a/books/assembly-kafka-zookeeper-authorization.adoc
+++ b/books/assembly-kafka-zookeeper-authorization.adoc
@@ -4,9 +4,9 @@
 
 [id='assembly-kafka-zookeeper-authorization-{context}']
 
-= Zookeeper authorization
+= {Zookeeper} authorization
 
-When authentication is enabled between Kafka and Zookeeper, you can use Zookeeper Access Control List (ACL) rules to automatically control access to Kafka's metadata stored in Zookeeper.
+When authentication is enabled between Kafka and {Zookeeper}, you can use {Zookeeper} Access Control List (ACL) rules to automatically control access to Kafka's metadata stored in {Zookeeper}.
 
 include::con-kafka-zookeeper-authorization-enabling-acls.adoc[leveloffset=+1]
 

--- a/books/assembly-monitoring.adoc
+++ b/books/assembly-monitoring.adoc
@@ -6,11 +6,11 @@
 
 = Monitoring your cluster using JMX
 
-{Zookeeper}, the Kafka broker, Kafka Connect, and the Kafka clients all expose management information using link:https://www.oracle.com/technetwork/articles/java/javamanagement-140525.html[Java Management Extensions, window="_blank"] (JMX). Most management information is in the form of metrics that are useful for monitoring the condition and performance of your Kafka cluster. Like other Java applications, Kafka provides this management information through managed beans or MBeans.
+ZooKeeper, the Kafka broker, Kafka Connect, and the Kafka clients all expose management information using link:https://www.oracle.com/technetwork/articles/java/javamanagement-140525.html[Java Management Extensions, window="_blank"] (JMX). Most management information is in the form of metrics that are useful for monitoring the condition and performance of your Kafka cluster. Like other Java applications, Kafka provides this management information through managed beans or MBeans.
 
-JMX works at the level of the JVM (Java Virtual Machine). To obtain management information, external tools can connect to the JVM that is running {Zookeeper}, the Kafka broker, and so on. By default, only tools on the same machine and running as the same user as the JVM are able to connect.
+JMX works at the level of the JVM (Java Virtual Machine). To obtain management information, external tools can connect to the JVM that is running ZooKeeper, the Kafka broker, and so on. By default, only tools on the same machine and running as the same user as the JVM are able to connect.
 
-NOTE: Management information for {Zookeeper} is not documented here. You can view {Zookeeper} metrics in JConsole. For more information, see xref:con-monitoring-using-jconsole-str[Monitoring using JConsole]. 
+NOTE: Management information for ZooKeeper is not documented here. You can view ZooKeeper metrics in JConsole. For more information, see xref:con-monitoring-using-jconsole-str[Monitoring using JConsole]. 
 
 include::con-jmx-configuration-options.adoc[leveloffset=+1]
 

--- a/books/assembly-monitoring.adoc
+++ b/books/assembly-monitoring.adoc
@@ -6,11 +6,11 @@
 
 = Monitoring your cluster using JMX
 
-Zookeeper, the Kafka broker, Kafka Connect, and the Kafka clients all expose management information using link:https://www.oracle.com/technetwork/articles/java/javamanagement-140525.html[Java Management Extensions, window="_blank"] (JMX). Most management information is in the form of metrics that are useful for monitoring the condition and performance of your Kafka cluster. Like other Java applications, Kafka provides this management information through managed beans or MBeans.
+{Zookeeper}, the Kafka broker, Kafka Connect, and the Kafka clients all expose management information using link:https://www.oracle.com/technetwork/articles/java/javamanagement-140525.html[Java Management Extensions, window="_blank"] (JMX). Most management information is in the form of metrics that are useful for monitoring the condition and performance of your Kafka cluster. Like other Java applications, Kafka provides this management information through managed beans or MBeans.
 
-JMX works at the level of the JVM (Java Virtual Machine). To obtain management information, external tools can connect to the JVM that is running Zookeeper, the Kafka broker, and so on. By default, only tools on the same machine and running as the same user as the JVM are able to connect.
+JMX works at the level of the JVM (Java Virtual Machine). To obtain management information, external tools can connect to the JVM that is running {Zookeeper}, the Kafka broker, and so on. By default, only tools on the same machine and running as the same user as the JVM are able to connect.
 
-NOTE: Management information for Zookeeper is not documented here. You can view Zookeeper metrics in JConsole. For more information, see xref:con-monitoring-using-jconsole-str[Monitoring using JConsole]. 
+NOTE: Management information for {Zookeeper} is not documented here. You can view {Zookeeper} metrics in JConsole. For more information, see xref:con-monitoring-using-jconsole-str[Monitoring using JConsole]. 
 
 include::con-jmx-configuration-options.adoc[leveloffset=+1]
 

--- a/books/assembly-overview.adoc
+++ b/books/assembly-overview.adoc
@@ -9,18 +9,18 @@
 [id='overview-{context}']
 = Overview of AMQ Streams
 
-Red Hat AMQ Streams is a massively-scalable, distributed, and high-performance data streaming platform based on the Apache {Zookeeper} and Apache Kafka projects.
+Red Hat AMQ Streams is a massively-scalable, distributed, and high-performance data streaming platform based on the Apache ZooKeeper and Apache Kafka projects.
 It consists of the following main components:
 
-{Zookeeper}:: Service for highly reliable distributed coordination.
+ZooKeeper:: Service for highly reliable distributed coordination.
 Kafka Broker:: Messaging broker responsible for delivering records from producing clients to consuming clients.
 Kafka Connect:: A toolkit for streaming data between Kafka brokers and other systems using _Connector_ plugins.
 Kafka Consumer and Producer APIs:: Java based APIs for producing and consuming messages to and from Kafka brokers.
 Kafka Streams API:: API for writing _stream processor_ applications.
 
 A cluster of Kafka brokers is the hub connecting all these components. 
-The broker uses Apache {Zookeeper} for storing configuration data and for cluster coordination. 
-Before running Apache Kafka, an Apache {Zookeeper} cluster has to be ready.
+The broker uses Apache ZooKeeper for storing configuration data and for cluster coordination. 
+Before running Apache Kafka, an Apache ZooKeeper cluster has to be ready.
 
 .Example Architecture diagram of AMQ Streams
 image::AMQ_Streams_478987_0918_01.png[AMQ Streams architecture]

--- a/books/assembly-overview.adoc
+++ b/books/assembly-overview.adoc
@@ -9,18 +9,18 @@
 [id='overview-{context}']
 = Overview of AMQ Streams
 
-Red Hat AMQ Streams is a massively-scalable, distributed, and high-performance data streaming platform based on the Apache Zookeeper and Apache Kafka projects.
+Red Hat AMQ Streams is a massively-scalable, distributed, and high-performance data streaming platform based on the Apache {Zookeeper} and Apache Kafka projects.
 It consists of the following main components:
 
-Zookeeper:: Service for highly reliable distributed coordination.
+{Zookeeper}:: Service for highly reliable distributed coordination.
 Kafka Broker:: Messaging broker responsible for delivering records from producing clients to consuming clients.
 Kafka Connect:: A toolkit for streaming data between Kafka brokers and other systems using _Connector_ plugins.
 Kafka Consumer and Producer APIs:: Java based APIs for producing and consuming messages to and from Kafka brokers.
 Kafka Streams API:: API for writing _stream processor_ applications.
 
 A cluster of Kafka brokers is the hub connecting all these components. 
-The broker uses Apache Zookeeper for storing configuration data and for cluster coordination. 
-Before running Apache Kafka, an Apache Zookeeper cluster has to be ready.
+The broker uses Apache {Zookeeper} for storing configuration data and for cluster coordination. 
+Before running Apache Kafka, an Apache {Zookeeper} cluster has to be ready.
 
 .Example Architecture diagram of AMQ Streams
 image::AMQ_Streams_478987_0918_01.png[AMQ Streams architecture]

--- a/books/common/attributes.adoc
+++ b/books/common/attributes.adoc
@@ -22,7 +22,6 @@
 :BaseProductVersion: 7.5
 :BaseProductMajorVersion: 7
 :ProductPlatformName: Red Hat Enterprise Linux
-:Zookeeper: ZooKeeper
 :oauth: OAuth 2.0
 :ssoVersion: 7.3
 

--- a/books/common/attributes.adoc
+++ b/books/common/attributes.adoc
@@ -22,6 +22,7 @@
 :BaseProductVersion: 7.5
 :BaseProductMajorVersion: 7
 :ProductPlatformName: Red Hat Enterprise Linux
+:Zookeeper: ZooKeeper
 :oauth: OAuth 2.0
 :ssoVersion: 7.3
 
@@ -69,6 +70,9 @@
 
 // File locations
 :UpstreamDir: upstream/documentation/book
+
+//Format attributes
+:underscore: _
 
 // Section enablers
 //:Kubernetes:

--- a/books/con-considerations-for-data-storage.adoc
+++ b/books/con-considerations-for-data-storage.adoc
@@ -12,14 +12,14 @@ An efficient data storage infrastructure is essential to the optimal performance
 
 Choose local storage when possible. If local storage is not available, you can use a Storage Area Network (SAN) accessed by a protocol such as Fibre Channel or iSCSI.
 
-== Apache Kafka and {Zookeeper} storage support
-Use separate disks for Apache Kafka and {Zookeeper}.
+== Apache Kafka and ZooKeeper storage support
+Use separate disks for Apache Kafka and ZooKeeper.
 
 Kafka supports JBOD (Just a Bunch of Disks) storage, a data storage configuration of multiple disks or volumes. JBOD provides increased data storage for Kafka brokers. It can also improve performance.
 
-Solid-state drives (SSDs), though not essential, can improve the performance of Kafka in large clusters where data is sent to and received from multiple topics asynchronously. SSDs are particularly effective with {Zookeeper}, which requires fast, low latency data access.
+Solid-state drives (SSDs), though not essential, can improve the performance of Kafka in large clusters where data is sent to and received from multiple topics asynchronously. SSDs are particularly effective with ZooKeeper, which requires fast, low latency data access.
 
-NOTE: You do not need to provision replicated storage because Kafka and {Zookeeper} both have built-in data replication.
+NOTE: You do not need to provision replicated storage because Kafka and ZooKeeper both have built-in data replication.
 
 == File systems
 It is recommended that you configure your storage system to use the XFS file system. AMQ Streams is also compatible with the ext4 file system, but this might require additional configuration for best results.

--- a/books/con-considerations-for-data-storage.adoc
+++ b/books/con-considerations-for-data-storage.adoc
@@ -12,14 +12,14 @@ An efficient data storage infrastructure is essential to the optimal performance
 
 Choose local storage when possible. If local storage is not available, you can use a Storage Area Network (SAN) accessed by a protocol such as Fibre Channel or iSCSI.
 
-== Apache Kafka and Zookeeper storage support
-Use separate disks for Apache Kafka and Zookeeper.
+== Apache Kafka and {Zookeeper} storage support
+Use separate disks for Apache Kafka and {Zookeeper}.
 
 Kafka supports JBOD (Just a Bunch of Disks) storage, a data storage configuration of multiple disks or volumes. JBOD provides increased data storage for Kafka brokers. It can also improve performance.
 
-Solid-state drives (SSDs), though not essential, can improve the performance of Kafka in large clusters where data is sent to and received from multiple topics asynchronously. SSDs are particularly effective with Zookeeper, which requires fast, low latency data access.
+Solid-state drives (SSDs), though not essential, can improve the performance of Kafka in large clusters where data is sent to and received from multiple topics asynchronously. SSDs are particularly effective with {Zookeeper}, which requires fast, low latency data access.
 
-NOTE: You do not need to provision replicated storage because Kafka and Zookeeper both have built-in data replication.
+NOTE: You do not need to provision replicated storage because Kafka and {Zookeeper} both have built-in data replication.
 
 == File systems
 It is recommended that you configure your storage system to use the XFS file system. AMQ Streams is also compatible with the ext4 file system, but this might require additional configuration for best results.

--- a/books/con-important-broker-metrics.adoc
+++ b/books/con-important-broker-metrics.adoc
@@ -102,14 +102,14 @@ m¦kafka.server:type=Request
 ¦The number of requests that are exempt from throttling.
 ¦N/A
 
-¦{Zookeeper} request latency in milliseconds
+¦ZooKeeper request latency in milliseconds
 m¦kafka.server:type=ZooKeeperClientMetrics,name=ZooKeeperRequestLatencyMs
-¦The latency for {Zookeeper} requests from the broker, in milliseconds.
+¦The latency for ZooKeeper requests from the broker, in milliseconds.
 ¦N/A
 
-¦{Zookeeper} session state
+¦ZooKeeper session state
 m¦kafka.server:type=SessionExpireListener,name=SessionState
-¦The status of the broker's connection to {Zookeeper}.
+¦The status of the broker's connection to ZooKeeper.
 ¦CONNECTED
 
 |===

--- a/books/con-important-broker-metrics.adoc
+++ b/books/con-important-broker-metrics.adoc
@@ -102,14 +102,14 @@ m¦kafka.server:type=Request
 ¦The number of requests that are exempt from throttling.
 ¦N/A
 
-¦Zookeeper request latency in milliseconds
+¦{Zookeeper} request latency in milliseconds
 m¦kafka.server:type=ZooKeeperClientMetrics,name=ZooKeeperRequestLatencyMs
-¦The latency for ZooKeeper requests from the broker, in milliseconds.
+¦The latency for {Zookeeper} requests from the broker, in milliseconds.
 ¦N/A
 
-¦Zookeeper session state
+¦{Zookeeper} session state
 m¦kafka.server:type=SessionExpireListener,name=SessionState
-¦The status of the broker's connection to Zookeeper.
+¦The status of the broker's connection to {Zookeeper}.
 ¦CONNECTED
 
 |===

--- a/books/con-kafka-authentication.adoc
+++ b/books/con-kafka-authentication.adoc
@@ -45,7 +45,7 @@ When TLS client authentication is not used and SASL is disabled, the principal n
 == SASL authentication
 
 SASL authentication is configured using Java Authentication and Authorization Service (JAAS).
-JAAS is also used for authentication of connections between Kafka and {Zookeeper}.
+JAAS is also used for authentication of connections between Kafka and ZooKeeper.
 JAAS uses its own configuration file.
 The recommended location for this file is `/opt/kafka/config/jaas.conf`.
 The file has to be readable by the `kafka` user.
@@ -67,8 +67,8 @@ Usernames and passwords are stored locally in Kafka configuration.
 
 `SCRAM-SHA-256` and `SCRAM-SHA-512`::
 Implements authentication using Salted Challenge Response Authentication Mechanism (SCRAM).
-SCRAM credentials are stored centrally in {Zookeeper}.
-SCRAM can be used in situations where {Zookeeper} cluster nodes are running isolated in a private network.
+SCRAM credentials are stored centrally in ZooKeeper.
+SCRAM can be used in situations where ZooKeeper cluster nodes are running isolated in a private network.
 
 `GSSAPI`::
 Implements authentication against a Kerberos server.
@@ -149,7 +149,7 @@ For example:
 sasl.enabled.mechanisms=SCRAM-SHA-256,SCRAM-SHA-512
 sasl.mechanism.inter.broker.protocol=SCRAM-SHA-512
 
-User credentials for the SCRAM mechanism are stored in {Zookeeper}.
+User credentials for the SCRAM mechanism are stored in ZooKeeper.
 The `kafka-configs.sh` tool can be used to manage them.
 For example, run the following command to add user user1 with password 123456:
 

--- a/books/con-kafka-authentication.adoc
+++ b/books/con-kafka-authentication.adoc
@@ -45,7 +45,7 @@ When TLS client authentication is not used and SASL is disabled, the principal n
 == SASL authentication
 
 SASL authentication is configured using Java Authentication and Authorization Service (JAAS).
-JAAS is also used for authentication of connections between Kafka and Zookeeper.
+JAAS is also used for authentication of connections between Kafka and {Zookeeper}.
 JAAS uses its own configuration file.
 The recommended location for this file is `/opt/kafka/config/jaas.conf`.
 The file has to be readable by the `kafka` user.
@@ -67,8 +67,8 @@ Usernames and passwords are stored locally in Kafka configuration.
 
 `SCRAM-SHA-256` and `SCRAM-SHA-512`::
 Implements authentication using Salted Challenge Response Authentication Mechanism (SCRAM).
-SCRAM credentials are stored centrally in Zookeeper.
-SCRAM can be used in situations where Zookeeper cluster nodes are running isolated in a private network.
+SCRAM credentials are stored centrally in {Zookeeper}.
+SCRAM can be used in situations where {Zookeeper} cluster nodes are running isolated in a private network.
 
 `GSSAPI`::
 Implements authentication against a Kerberos server.
@@ -149,7 +149,7 @@ For example:
 sasl.enabled.mechanisms=SCRAM-SHA-256,SCRAM-SHA-512
 sasl.mechanism.inter.broker.protocol=SCRAM-SHA-512
 
-User credentials for the SCRAM mechanism are stored in Zookeeper.
+User credentials for the SCRAM mechanism are stored in {Zookeeper}.
 The `kafka-configs.sh` tool can be used to manage them.
 For example, run the following command to add user user1 with password 123456:
 

--- a/books/con-kafka-zookeeper-authentication-jaas.adoc
+++ b/books/con-kafka-zookeeper-authentication-jaas.adoc
@@ -6,8 +6,8 @@
 
 = JAAS Configuration
 
-SASL authentication for {Zookeeper} connections has to be configured in the JAAS configuration file.
-By default, Kafka will use the JAAS context named `Client` for connecting to {Zookeeper}.
+SASL authentication for ZooKeeper connections has to be configured in the JAAS configuration file.
+By default, Kafka will use the JAAS context named `Client` for connecting to ZooKeeper.
 The `Client` context should be configured in the `/opt/kafka/config/jass.conf` file.
 The context has to enable the `PLAIN` SASL authentication, as in the following example:
 

--- a/books/con-kafka-zookeeper-authentication-jaas.adoc
+++ b/books/con-kafka-zookeeper-authentication-jaas.adoc
@@ -6,8 +6,8 @@
 
 = JAAS Configuration
 
-SASL authentication for Zookeeper connections has to be configured in the JAAS configuration file.
-By default, Kafka will use the JAAS context named `Client` for connecting to Zookeeper.
+SASL authentication for {Zookeeper} connections has to be configured in the JAAS configuration file.
+By default, Kafka will use the JAAS context named `Client` for connecting to {Zookeeper}.
 The `Client` context should be configured in the `/opt/kafka/config/jass.conf` file.
 The context has to enable the `PLAIN` SASL authentication, as in the following example:
 

--- a/books/con-kafka-zookeeper-authorization-enabling-acls.adoc
+++ b/books/con-kafka-zookeeper-authorization-enabling-acls.adoc
@@ -6,7 +6,7 @@
 
 = ACL Configuration
 
-Enforcement of {Zookeeper} ACL rules is controlled by the `zookeeper.set.acl` property in the `config/server.properties` Kafka configuration file.
+Enforcement of ZooKeeper ACL rules is controlled by the `zookeeper.set.acl` property in the `config/server.properties` Kafka configuration file.
 
 The property is disabled by default and enabled by setting to `true`:
 
@@ -15,20 +15,20 @@ The property is disabled by default and enabled by setting to `true`:
 zookeeper.set.acl=true
 ----
 
-If ACL rules are enabled, when a `znode` is created in {Zookeeper} only the Kafka user who created it can modify or delete it.
+If ACL rules are enabled, when a `znode` is created in ZooKeeper only the Kafka user who created it can modify or delete it.
 All other users have read-only access.
 
-Kafka sets ACL rules only for newly created {Zookeeper} `znodes`.
+Kafka sets ACL rules only for newly created ZooKeeper `znodes`.
 If the ACLs are only enabled after the first start of the cluster, the `zookeeper-security-migration.sh` tool can set ACLs on all existing `znodes`.
 
-.Confidentiality of data in {Zookeeper}
+.Confidentiality of data in ZooKeeper
 
-Data stored in {Zookeeper} includes:
+Data stored in ZooKeeper includes:
 
 * Topic names and their configuration
 * Salted and hashed user credentials when SASL SCRAM authentication is used.
 
-But {Zookeeper} does not store any records sent and received using Kafka.
-The data stored in {Zookeeper} is assumed to be non-confidential.
+But ZooKeeper does not store any records sent and received using Kafka.
+The data stored in ZooKeeper is assumed to be non-confidential.
 
-If the data is to be regarded as confidential (for example because topic names contain customer IDs), the only option available for protection is isolating {Zookeeper} on the network level and allowing access only to Kafka brokers.
+If the data is to be regarded as confidential (for example because topic names contain customer IDs), the only option available for protection is isolating ZooKeeper on the network level and allowing access only to Kafka brokers.

--- a/books/con-kafka-zookeeper-authorization-enabling-acls.adoc
+++ b/books/con-kafka-zookeeper-authorization-enabling-acls.adoc
@@ -6,7 +6,7 @@
 
 = ACL Configuration
 
-Enforcement of Zookeeper ACL rules is controlled by the `zookeeper.set.acl` property in the `config/server.properties` Kafka configuration file.
+Enforcement of {Zookeeper} ACL rules is controlled by the `zookeeper.set.acl` property in the `config/server.properties` Kafka configuration file.
 
 The property is disabled by default and enabled by setting to `true`:
 
@@ -15,20 +15,20 @@ The property is disabled by default and enabled by setting to `true`:
 zookeeper.set.acl=true
 ----
 
-If ACL rules are enabled, when a `znode` is created in Zookeeper only the Kafka user who created it can modify or delete it.
+If ACL rules are enabled, when a `znode` is created in {Zookeeper} only the Kafka user who created it can modify or delete it.
 All other users have read-only access.
 
-Kafka sets ACL rules only for newly created Zookeeper `znodes`.
+Kafka sets ACL rules only for newly created {Zookeeper} `znodes`.
 If the ACLs are only enabled after the first start of the cluster, the `zookeeper-security-migration.sh` tool can set ACLs on all existing `znodes`.
 
-.Confidentiality of data in Zookeeper
+.Confidentiality of data in {Zookeeper}
 
-Data stored in Zookeeper includes:
+Data stored in {Zookeeper} includes:
 
 * Topic names and their configuration
 * Salted and hashed user credentials when SASL SCRAM authentication is used.
 
-But Zookeeper does not store any records sent and received using Kafka.
-The data stored in Zookeeper is assumed to be non-confidential.
+But {Zookeeper} does not store any records sent and received using Kafka.
+The data stored in {Zookeeper} is assumed to be non-confidential.
 
-If the data is to be regarded as confidential (for example because topic names contain customer IDs), the only option available for protection is isolating Zookeeper on the network level and allowing access only to Kafka brokers.
+If the data is to be regarded as confidential (for example because topic names contain customer IDs), the only option available for protection is isolating {Zookeeper} on the network level and allowing access only to Kafka brokers.

--- a/books/con-kafka-zookeeper-configuration.adoc
+++ b/books/con-kafka-zookeeper-configuration.adoc
@@ -4,10 +4,10 @@
 
 [id='con-kafka-zookeeper-configuration-{context}']
 
-= {Zookeeper}
+= ZooKeeper
 
-Kafka brokers need {Zookeeper} to store some parts of their configuration as well as to coordinate the cluster (for example to decide which node is a leader for which partition).
-Connection details for the {Zookeeper} cluster are stored in the configuration file.
+Kafka brokers need ZooKeeper to store some parts of their configuration as well as to coordinate the cluster (for example to decide which node is a leader for which partition).
+Connection details for the ZooKeeper cluster are stored in the configuration file.
 The field `zookeeper.connect` contains a comma-separated list of hostnames and ports of members of the zookeeper cluster. 
 
 For example:
@@ -17,10 +17,10 @@ For example:
 zookeeper.connect=zoo1.my-domain.com:2181,zoo2.my-domain.com:2181,zoo3.my-domain.com:2181
 ----
 
-Kafka will use these addresses to connect to the {Zookeeper} cluster.
-With this configuration, all Kafka `znodes` will be created directly in the root of {Zookeeper} database.
-Therefore, such a {Zookeeper} cluster could be used only for a single Kafka cluster.
-To configure multiple Kafka clusters to use single {Zookeeper} cluster, specify a base (prefix) path at the end of the {Zookeeper} connection string in the Kafka configuration file:
+Kafka will use these addresses to connect to the ZooKeeper cluster.
+With this configuration, all Kafka `znodes` will be created directly in the root of ZooKeeper database.
+Therefore, such a ZooKeeper cluster could be used only for a single Kafka cluster.
+To configure multiple Kafka clusters to use single ZooKeeper cluster, specify a base (prefix) path at the end of the ZooKeeper connection string in the Kafka configuration file:
 
 [source,ini]
 ----

--- a/books/con-kafka-zookeeper-configuration.adoc
+++ b/books/con-kafka-zookeeper-configuration.adoc
@@ -4,10 +4,10 @@
 
 [id='con-kafka-zookeeper-configuration-{context}']
 
-= Zookeeper
+= {Zookeeper}
 
-Kafka brokers need Zookeeper to store some parts of their configuration as well as to coordinate the cluster (for example to decide which node is a leader for which partition).
-Connection details for the Zookeeper cluster are stored in the configuration file.
+Kafka brokers need {Zookeeper} to store some parts of their configuration as well as to coordinate the cluster (for example to decide which node is a leader for which partition).
+Connection details for the {Zookeeper} cluster are stored in the configuration file.
 The field `zookeeper.connect` contains a comma-separated list of hostnames and ports of members of the zookeeper cluster. 
 
 For example:
@@ -17,10 +17,10 @@ For example:
 zookeeper.connect=zoo1.my-domain.com:2181,zoo2.my-domain.com:2181,zoo3.my-domain.com:2181
 ----
 
-Kafka will use these addresses to connect to the Zookeeper cluster.
-With this configuration, all Kafka `znodes` will be created directly in the root of Zookeeper database.
-Therefore, such a Zookeeper cluster could be used only for a single Kafka cluster.
-To configure multiple Kafka clusters to use single Zookeeper cluster, specify a base (prefix) path at the end of the Zookeeper connection string in the Kafka configuration file:
+Kafka will use these addresses to connect to the {Zookeeper} cluster.
+With this configuration, all Kafka `znodes` will be created directly in the root of {Zookeeper} database.
+Therefore, such a {Zookeeper} cluster could be used only for a single Kafka cluster.
+To configure multiple Kafka clusters to use single {Zookeeper} cluster, specify a base (prefix) path at the end of the {Zookeeper} connection string in the Kafka configuration file:
 
 [source,ini]
 ----

--- a/books/con-monitoring-using-jconsole.adoc
+++ b/books/con-monitoring-using-jconsole.adoc
@@ -15,7 +15,7 @@ If using JConsole to connect to a local JVM, the names of the JVM processes corr
 ¦AMQ Streams component
 ¦JVM process
 
-¦Zookeeper
+¦{Zookeeper}
 ¦`org.apache.zookeeper.server.quorum.QuorumPeerMain`
 
 ¦Kafka broker

--- a/books/con-monitoring-using-jconsole.adoc
+++ b/books/con-monitoring-using-jconsole.adoc
@@ -15,7 +15,7 @@ If using JConsole to connect to a local JVM, the names of the JVM processes corr
 ¦AMQ Streams component
 ¦JVM process
 
-¦{Zookeeper}
+¦ZooKeeper
 ¦`org.apache.zookeeper.server.quorum.QuorumPeerMain`
 
 ¦Kafka broker

--- a/books/con-reassignment-of-partitions.adoc
+++ b/books/con-reassignment-of-partitions.adoc
@@ -84,12 +84,12 @@ Partitions not included in the JSON are not changed.
 
 The easiest way to assign all the partitions for a given set of topics to a given set of brokers is to generate a reassignment JSON file using the `kafka-reassign-partitions.sh --generate`, command.
 
-[source,subs=+quotes]
+[source,shell,subs="+quotes,attributes"]
 ----
-bin/kafka-reassign-partitions.sh --zookeeper _<Zookeeper>_ --topics-to-move-json-file _<TopicsFile>_ --broker-list _<BrokerList>_ --generate
+bin/kafka-reassign-partitions.sh --zookeeper _<{Zookeeper}>_ --topics-to-move-json-file _<TopicsFile>_ --broker-list _<BrokerList>_ --generate
 ----
 
-The `_<TopicsFile>_` is a JSON file which lists the topics to move. 
+The `_<TopicsFile>_` is a JSON file which lists the topics to move.
 It has the following structure:
 
 [source,subs=+quotes]

--- a/books/con-reassignment-of-partitions.adoc
+++ b/books/con-reassignment-of-partitions.adoc
@@ -86,7 +86,7 @@ The easiest way to assign all the partitions for a given set of topics to a give
 
 [source,shell,subs="+quotes,attributes"]
 ----
-bin/kafka-reassign-partitions.sh --zookeeper _<{Zookeeper}>_ --topics-to-move-json-file _<TopicsFile>_ --broker-list _<BrokerList>_ --generate
+bin/kafka-reassign-partitions.sh --zookeeper _<ZooKeeper>_ --topics-to-move-json-file _<TopicsFile>_ --broker-list _<BrokerList>_ --generate
 ----
 
 The `_<TopicsFile>_` is a JSON file which lists the topics to move.

--- a/books/con-zookeeeper-cluster-configuration.adoc
+++ b/books/con-zookeeeper-cluster-configuration.adoc
@@ -4,35 +4,35 @@
 
 [id='con-zookeeeper-cluster-configuration-{context}']
 
-= Zookeeper cluster configuration
+= {Zookeeper} cluster configuration
 
-For reliable ZooKeeper service, you should deploy ZooKeeper in a cluster.
-Hence, for production use cases, you must run a cluster of replicated Zookeeper instances.
-Zookeeper clusters are also referred as ensembles.
+For reliable {Zookeeper} service, you should deploy {Zookeeper} in a cluster.
+Hence, for production use cases, you must run a cluster of replicated {Zookeeper} instances.
+{Zookeeper} clusters are also referred as ensembles.
 
-Zookeeper clusters usually consist of an odd number of nodes.
-Zookeeper requires a majority of the nodes in the cluster should be up and running.
+{Zookeeper} clusters usually consist of an odd number of nodes.
+{Zookeeper} requires a majority of the nodes in the cluster should be up and running.
 For example, a cluster with three nodes, at least two of them must be up and running.
 This means it can tolerate one node being down.
 A cluster consisting of five nodes, at least three nodes must be available.
 This means it can tolerate two nodes being down.
 A cluster consisting of seven nodes, at least four nodes must be available.
 This means it can tolerate three nodes being down.
-Having more nodes in the Zookeeper cluster delivers better resiliency and reliability of the whole cluster.
+Having more nodes in the {Zookeeper} cluster delivers better resiliency and reliability of the whole cluster.
 
-Zookeeper can run in clusters with an even number of nodes. 
+{Zookeeper} can run in clusters with an even number of nodes. 
 The additional node, however, does not increase the resiliency of the cluster. 
 A cluster with four nodes requires at least three nodes to be available and can tolerate only one node being down.
 Therefore it has exactly the same resiliency as a cluster with only three nodes.
 
-The different Zookeeper nodes should be ideally placed into different data centers or network segments.
-Increasing the number of Zookeeper nodes increases the workload spent on cluster synchronization. 
-For most Kafka use cases Zookeeper cluster with 3, 5 or 7 nodes should be fully sufficient.
+The different {Zookeeper} nodes should be ideally placed into different data centers or network segments.
+Increasing the number of {Zookeeper} nodes increases the workload spent on cluster synchronization. 
+For most Kafka use cases {Zookeeper} cluster with 3, 5 or 7 nodes should be fully sufficient.
 
-WARNING: Zookeeper cluster with 3 nodes can tolerate only 1 unavailable node. 
-This means that when a cluster node crashes while you are doing maintenance on another node your Zookeeper cluster will be unavailable.
+WARNING: {Zookeeper} cluster with 3 nodes can tolerate only 1 unavailable node. 
+This means that when a cluster node crashes while you are doing maintenance on another node your {Zookeeper} cluster will be unavailable.
 
-Replicated Zookeeper configuration supports all configuration options supported by the standalone configuration.
+Replicated {Zookeeper} configuration supports all configuration options supported by the standalone configuration.
 Additional options are added for the clustering configuration:
 
 `initLimit`:: Amount of time to allow followers to connect and sync to the cluster leader. 
@@ -40,15 +40,15 @@ The time is specified as a number of ticks (see the xref:con-zookeeper-basic-con
 `syncLimit`:: Amount of time for which followers can be behind the leader.
 The time is specified as a number of ticks (see the xref:con-zookeeper-basic-configuration-{context}[`timeTick` option] for more details).
 
-In addition to the options above, every configuration file should contain a list of servers which should be members of the Zookeeper cluster. 
+In addition to the options above, every configuration file should contain a list of servers which should be members of the {Zookeeper} cluster. 
 The server records should be specified in the format `server.id=hostname:port1:port2`, where:
 
-`id`:: The ID of the Zookeeper cluster node.
+`id`:: The ID of the {Zookeeper} cluster node.
 `hostname`:: The hostname or IP address where the node listens for connections.
 `port1`:: The port number used for intra-cluster communication.
 `port2`:: The port number used for leader election.
 
-The following is an example configuration file of a Zookeeper cluster with three nodes:
+The following is an example configuration file of a {Zookeeper} cluster with three nodes:
 
 [source,ini]
 ----
@@ -63,12 +63,12 @@ server.2=172.17.0.2:2888:3888
 server.3=172.17.0.3:2888:3888
 ----
 
-Each node in the Zookeeper cluster has to be assigned with a unique `ID`.
+Each node in the {Zookeeper} cluster has to be assigned with a unique `ID`.
 Each node’s `ID` has to be configured in `myid` file and stored in the `dataDir` folder like `/var/lib/zookeeper/`.
 The `myid` files should contain only a single line with the written `ID` as text. 
 The `ID` can be any integer from 1 to 255.
 You must manually create this file on each cluster node.
-Using this file, each Zookeeper instance will use the configuration from the corresponding `server.` line in the configuration file to configure its listeners.
+Using this file, each {Zookeeper} instance will use the configuration from the corresponding `server.` line in the configuration file to configure its listeners.
 It will also use all other `server.` lines to identify other cluster members.
 
 In the above example, there are three nodes, so each one will have a different `myid` with values `1`, `2`, and `3` respectively.

--- a/books/con-zookeeeper-cluster-configuration.adoc
+++ b/books/con-zookeeeper-cluster-configuration.adoc
@@ -4,35 +4,35 @@
 
 [id='con-zookeeeper-cluster-configuration-{context}']
 
-= {Zookeeper} cluster configuration
+= ZooKeeper cluster configuration
 
-For reliable {Zookeeper} service, you should deploy {Zookeeper} in a cluster.
-Hence, for production use cases, you must run a cluster of replicated {Zookeeper} instances.
-{Zookeeper} clusters are also referred as ensembles.
+For reliable ZooKeeper service, you should deploy ZooKeeper in a cluster.
+Hence, for production use cases, you must run a cluster of replicated ZooKeeper instances.
+ZooKeeper clusters are also referred as ensembles.
 
-{Zookeeper} clusters usually consist of an odd number of nodes.
-{Zookeeper} requires a majority of the nodes in the cluster should be up and running.
+ZooKeeper clusters usually consist of an odd number of nodes.
+ZooKeeper requires a majority of the nodes in the cluster should be up and running.
 For example, a cluster with three nodes, at least two of them must be up and running.
 This means it can tolerate one node being down.
 A cluster consisting of five nodes, at least three nodes must be available.
 This means it can tolerate two nodes being down.
 A cluster consisting of seven nodes, at least four nodes must be available.
 This means it can tolerate three nodes being down.
-Having more nodes in the {Zookeeper} cluster delivers better resiliency and reliability of the whole cluster.
+Having more nodes in the ZooKeeper cluster delivers better resiliency and reliability of the whole cluster.
 
-{Zookeeper} can run in clusters with an even number of nodes. 
+ZooKeeper can run in clusters with an even number of nodes. 
 The additional node, however, does not increase the resiliency of the cluster. 
 A cluster with four nodes requires at least three nodes to be available and can tolerate only one node being down.
 Therefore it has exactly the same resiliency as a cluster with only three nodes.
 
-The different {Zookeeper} nodes should be ideally placed into different data centers or network segments.
-Increasing the number of {Zookeeper} nodes increases the workload spent on cluster synchronization. 
-For most Kafka use cases {Zookeeper} cluster with 3, 5 or 7 nodes should be fully sufficient.
+The different ZooKeeper nodes should be ideally placed into different data centers or network segments.
+Increasing the number of ZooKeeper nodes increases the workload spent on cluster synchronization. 
+For most Kafka use cases ZooKeeper cluster with 3, 5 or 7 nodes should be fully sufficient.
 
-WARNING: {Zookeeper} cluster with 3 nodes can tolerate only 1 unavailable node. 
-This means that when a cluster node crashes while you are doing maintenance on another node your {Zookeeper} cluster will be unavailable.
+WARNING: ZooKeeper cluster with 3 nodes can tolerate only 1 unavailable node. 
+This means that when a cluster node crashes while you are doing maintenance on another node your ZooKeeper cluster will be unavailable.
 
-Replicated {Zookeeper} configuration supports all configuration options supported by the standalone configuration.
+Replicated ZooKeeper configuration supports all configuration options supported by the standalone configuration.
 Additional options are added for the clustering configuration:
 
 `initLimit`:: Amount of time to allow followers to connect and sync to the cluster leader. 
@@ -40,15 +40,15 @@ The time is specified as a number of ticks (see the xref:con-zookeeper-basic-con
 `syncLimit`:: Amount of time for which followers can be behind the leader.
 The time is specified as a number of ticks (see the xref:con-zookeeper-basic-configuration-{context}[`timeTick` option] for more details).
 
-In addition to the options above, every configuration file should contain a list of servers which should be members of the {Zookeeper} cluster. 
+In addition to the options above, every configuration file should contain a list of servers which should be members of the ZooKeeper cluster. 
 The server records should be specified in the format `server.id=hostname:port1:port2`, where:
 
-`id`:: The ID of the {Zookeeper} cluster node.
+`id`:: The ID of the ZooKeeper cluster node.
 `hostname`:: The hostname or IP address where the node listens for connections.
 `port1`:: The port number used for intra-cluster communication.
 `port2`:: The port number used for leader election.
 
-The following is an example configuration file of a {Zookeeper} cluster with three nodes:
+The following is an example configuration file of a ZooKeeper cluster with three nodes:
 
 [source,ini]
 ----
@@ -63,12 +63,12 @@ server.2=172.17.0.2:2888:3888
 server.3=172.17.0.3:2888:3888
 ----
 
-Each node in the {Zookeeper} cluster has to be assigned with a unique `ID`.
+Each node in the ZooKeeper cluster has to be assigned with a unique `ID`.
 Each node’s `ID` has to be configured in `myid` file and stored in the `dataDir` folder like `/var/lib/zookeeper/`.
 The `myid` files should contain only a single line with the written `ID` as text. 
 The `ID` can be any integer from 1 to 255.
 You must manually create this file on each cluster node.
-Using this file, each {Zookeeper} instance will use the configuration from the corresponding `server.` line in the configuration file to configure its listeners.
+Using this file, each ZooKeeper instance will use the configuration from the corresponding `server.` line in the configuration file to configure its listeners.
 It will also use all other `server.` lines to identify other cluster members.
 
 In the above example, there are three nodes, so each one will have a different `myid` with values `1`, `2`, and `3` respectively.

--- a/books/con-zookeeper-authorization.adoc
+++ b/books/con-zookeeper-authorization.adoc
@@ -6,7 +6,7 @@
 
 = Authorization
 
-Zookeeper supports access control lists (ACLs) to protect data stored inside it.
-Kafka brokers can automatically configure the ACL rights for all Zookeeper records they create so no other Zookeeper user can modify them.
+{Zookeeper} supports access control lists (ACLs) to protect data stored inside it.
+Kafka brokers can automatically configure the ACL rights for all {Zookeeper} records they create so no other {Zookeeper} user can modify them.
 
-For more information about enabling Zookeeper ACLs in Kafka brokers, see xref:assembly-kafka-zookeeper-authorization-{context}[].
+For more information about enabling {Zookeeper} ACLs in Kafka brokers, see xref:assembly-kafka-zookeeper-authorization-{context}[].

--- a/books/con-zookeeper-authorization.adoc
+++ b/books/con-zookeeper-authorization.adoc
@@ -6,7 +6,7 @@
 
 = Authorization
 
-{Zookeeper} supports access control lists (ACLs) to protect data stored inside it.
-Kafka brokers can automatically configure the ACL rights for all {Zookeeper} records they create so no other {Zookeeper} user can modify them.
+ZooKeeper supports access control lists (ACLs) to protect data stored inside it.
+Kafka brokers can automatically configure the ACL rights for all ZooKeeper records they create so no other ZooKeeper user can modify them.
 
-For more information about enabling {Zookeeper} ACLs in Kafka brokers, see xref:assembly-kafka-zookeeper-authorization-{context}[].
+For more information about enabling ZooKeeper ACLs in Kafka brokers, see xref:assembly-kafka-zookeeper-authorization-{context}[].

--- a/books/con-zookeeper-basic-configuration.adoc
+++ b/books/con-zookeeper-basic-configuration.adoc
@@ -6,18 +6,18 @@
 
 = Basic configuration
 
-The most important Zookeeper configuration options are:
+The most important {Zookeeper} configuration options are:
 
-`tickTime`:: Zookeeper’s basic time unit in milliseconds.
+`tickTime`:: {Zookeeper}’s basic time unit in milliseconds.
 It is used for heartbeats and session timeouts.
 For example, minimum session timeout will be two ticks.
-`dataDir`:: The directory where Zookeeper stores its transaction log and snapshots of its in-memory database. This should be set to the `/var/lib/zookeeper/` directory created during installation.
+`dataDir`:: The directory where {Zookeeper} stores its transaction log and snapshots of its in-memory database. This should be set to the `/var/lib/zookeeper/` directory created during installation.
 `clientPort`:: Port number where clients can connect. Defaults to `2181`.
 
-An example zookeeper configuration file `config/zookeeper.properties` is located in the AMQ Streams installation directory.
-It is recommended to place the `dataDir` directory on a separate disk device to minimize the latency in Zookeeper.
+An example {Zookeeper} configuration file `config/zookeeper.properties` is located in the AMQ Streams installation directory.
+It is recommended to place the `dataDir` directory on a separate disk device to minimize the latency in {Zookeeper}.
 
-Zookeeper configuration file should be located in `/opt/kafka/config/zookeeper.properties`.
+{Zookeeper} configuration file should be located in `/opt/kafka/config/zookeeper.properties`.
 A basic example of the configuration file can be found below.
 The configuration file has to be readable by the `kafka` user.
 

--- a/books/con-zookeeper-basic-configuration.adoc
+++ b/books/con-zookeeper-basic-configuration.adoc
@@ -6,18 +6,18 @@
 
 = Basic configuration
 
-The most important {Zookeeper} configuration options are:
+The most important ZooKeeper configuration options are:
 
-`tickTime`:: {Zookeeper}’s basic time unit in milliseconds.
+`tickTime`:: ZooKeeper’s basic time unit in milliseconds.
 It is used for heartbeats and session timeouts.
 For example, minimum session timeout will be two ticks.
-`dataDir`:: The directory where {Zookeeper} stores its transaction log and snapshots of its in-memory database. This should be set to the `/var/lib/zookeeper/` directory created during installation.
+`dataDir`:: The directory where ZooKeeper stores its transaction log and snapshots of its in-memory database. This should be set to the `/var/lib/zookeeper/` directory created during installation.
 `clientPort`:: Port number where clients can connect. Defaults to `2181`.
 
-An example {Zookeeper} configuration file `config/zookeeper.properties` is located in the AMQ Streams installation directory.
-It is recommended to place the `dataDir` directory on a separate disk device to minimize the latency in {Zookeeper}.
+An example ZooKeeper configuration file `config/zookeeper.properties` is located in the AMQ Streams installation directory.
+It is recommended to place the `dataDir` directory on a separate disk device to minimize the latency in ZooKeeper.
 
-{Zookeeper} configuration file should be located in `/opt/kafka/config/zookeeper.properties`.
+ZooKeeper configuration file should be located in `/opt/kafka/config/zookeeper.properties`.
 A basic example of the configuration file can be found below.
 The configuration file has to be readable by the `kafka` user.
 

--- a/books/con-zookeeper-logging.adoc
+++ b/books/con-zookeeper-logging.adoc
@@ -6,9 +6,9 @@
 
 = Logging
 
-Zookeeper is using _log4j_ as their logging infrastructure. 
+{Zookeeper} is using _log4j_ as their logging infrastructure. 
 Logging configuration is by default read from the `log4j.properties` configuration file which should be placed either in the `/opt/kafka/config/` directory or in the classpath. 
-The location and name of the configuration file can be changed using the Java property `log4j.configuration` which can be passed to Zookeeper using the `KAFKA_LOG4J_OPTS` environment variable:
+The location and name of the configuration file can be changed using the Java property `log4j.configuration` which can be passed to {Zookeeper} using the `KAFKA_LOG4J_OPTS` environment variable:
 
 [source]
 ----

--- a/books/con-zookeeper-logging.adoc
+++ b/books/con-zookeeper-logging.adoc
@@ -6,9 +6,9 @@
 
 = Logging
 
-{Zookeeper} is using _log4j_ as their logging infrastructure. 
+ZooKeeper is using _log4j_ as their logging infrastructure. 
 Logging configuration is by default read from the `log4j.properties` configuration file which should be placed either in the `/opt/kafka/config/` directory or in the classpath. 
-The location and name of the configuration file can be changed using the Java property `log4j.configuration` which can be passed to {Zookeeper} using the `KAFKA_LOG4J_OPTS` environment variable:
+The location and name of the configuration file can be changed using the Java property `log4j.configuration` which can be passed to ZooKeeper using the `KAFKA_LOG4J_OPTS` environment variable:
 
 [source]
 ----

--- a/books/con-zookeeper-sasl-authentication.adoc
+++ b/books/con-zookeeper-sasl-authentication.adoc
@@ -7,9 +7,9 @@
 = Authentication with SASL
 
 JAAS is configured using a separate configuration file.
-It is recommended to place the JAAS configuration file in the same directory as the Zookeeper configuration (`/opt/kafka/config/`).
+It is recommended to place the JAAS configuration file in the same directory as the {Zookeeper} configuration (`/opt/kafka/config/`).
 The recommended file name is `zookeeper-jaas.conf`.
-When using a Zookeeper cluster with multiple nodes, the JAAS configuration file has to be created on all cluster nodes.
+When using a {Zookeeper} cluster with multiple nodes, the JAAS configuration file has to be created on all cluster nodes.
 
 JAAS is configured using contexts.
 Separate parts such as the server and client are always configured with a separate _context_.
@@ -23,7 +23,7 @@ ContextName {
 };
 ----
 
-SASL Authentication is configured separately for server-to-server communication (communication between Zookeeper instances) and client-to-server communication (communication between Kafka and Zookeeper). Server-to-server authentication is relevant only for Zookeeper clusters with multiple nodes.
+SASL Authentication is configured separately for server-to-server communication (communication between {Zookeeper} instances) and client-to-server communication (communication between Kafka and {Zookeeper}). Server-to-server authentication is relevant only for {Zookeeper} clusters with multiple nodes.
 
 .Server-to-Server authentication
 
@@ -34,7 +34,7 @@ For server-to-server authentication, the JAAS configuration file contains two pa
 
 When using DIGEST-MD5 SASL mechanism, the `QuorumServer` context is used to configure the authentication server.
 It must contain all the usernames to be allowed to connect together with their passwords in an unencrypted form.
-The second context, `QuorumLearner`, has to be configured for the client which is built into Zookeeper.
+The second context, `QuorumLearner`, has to be configured for the client which is built into {Zookeeper}.
 It also contains the password in an unencrypted form.
 An example of the JAAS configuration file for DIGEST-MD5 mechanism can be found below:
 
@@ -52,7 +52,7 @@ QuorumLearner {
 };
 ----
 
-In addition to the JAAS configuration file, you must enable the server-to-server authentication in the regular Zookeeper configuration file by specifying the following options:
+In addition to the JAAS configuration file, you must enable the server-to-server authentication in the regular {Zookeeper} configuration file by specifying the following options:
 
 [source]
 ----
@@ -64,7 +64,7 @@ quorum.auth.server.loginContext=QuorumServer
 quorum.cnxn.threads.size=20
 ----
 
-Use the `KAFKA_OPTS` environment variable to pass the JAAS configuration file to the Zookeeper server as a Java property:
+Use the `KAFKA_OPTS` environment variable to pass the JAAS configuration file to the {Zookeeper} server as a Java property:
 
 [source]
 ----
@@ -73,14 +73,14 @@ export KAFKA_OPTS="-Djava.security.auth.login.config=/opt/kafka/config/zookeeper
 ----
 
 For more information about server-to-server authentication, see
-link:https://cwiki.apache.org/confluence/display/ZOOKEEPER/Server-Server+mutual+authentication[Zookeeper wiki^].
+link:https://cwiki.apache.org/confluence/display/ZOOKEEPER/Server-Server+mutual+authentication[{Zookeeper} wiki^].
 
 .Client-to-Server authentication
 
 Client-to-server authentication is configured in the same JAAS file as the server-to-server authentication.
 However, unlike the server-to-server authentication, it contains only the server configuration.
 The client part of the configuration has to be done in the client.
-For information on how to configure a Kafka broker to connect to Zookeeper using authentication, see the xref:assembly-kafka-zookeeper-authentication-{context}[Kafka installation] section.
+For information on how to configure a Kafka broker to connect to {Zookeeper} using authentication, see the xref:assembly-kafka-zookeeper-authentication-{context}[Kafka installation] section.
 
 Add the Server context to the JAAS configuration file to configure client-to-server authentication.
 For DIGEST-MD5 mechanism it configures all usernames and passwords:
@@ -95,7 +95,7 @@ Server {
 };
 ----
 
-After configuring the JAAS context, enable the client-to-server authentication in the Zookeeper configuration file by adding the following line:
+After configuring the JAAS context, enable the client-to-server authentication in the {Zookeeper} configuration file by adding the following line:
 
 [source]
 ----
@@ -105,9 +105,9 @@ authProvider.2=org.apache.zookeeper.server.auth.SASLAuthenticationProvider
 authProvider.3=org.apache.zookeeper.server.auth.SASLAuthenticationProvider
 ----
 
-You must add the `authProvider._<ID>_` property for every server that is part of the Zookeeper cluster.
+You must add the `authProvider._<ID>_` property for every server that is part of the {Zookeeper} cluster.
 
-Use the `KAFKA_OPTS` environment variable to pass the JAAS configuration file to the Zookeeper server as a Java property:
+Use the `KAFKA_OPTS` environment variable to pass the JAAS configuration file to the {Zookeeper} server as a Java property:
 
 [source]
 ----
@@ -115,4 +115,4 @@ su - kafka
 export KAFKA_OPTS="-Djava.security.auth.login.config=/opt/kafka/config/zookeeper-jaas.conf"; /opt/kafka/bin/zookeeper-server-start.sh -daemon /opt/kafka/config/zookeeper.properties
 ----
 
-For more information about configuring Zookeeper authentication in Kafka brokers, see xref:assembly-kafka-zookeeper-authentication-{context}[].
+For more information about configuring {Zookeeper} authentication in Kafka brokers, see xref:assembly-kafka-zookeeper-authentication-{context}[].

--- a/books/con-zookeeper-sasl-authentication.adoc
+++ b/books/con-zookeeper-sasl-authentication.adoc
@@ -7,9 +7,9 @@
 = Authentication with SASL
 
 JAAS is configured using a separate configuration file.
-It is recommended to place the JAAS configuration file in the same directory as the {Zookeeper} configuration (`/opt/kafka/config/`).
+It is recommended to place the JAAS configuration file in the same directory as the ZooKeeper configuration (`/opt/kafka/config/`).
 The recommended file name is `zookeeper-jaas.conf`.
-When using a {Zookeeper} cluster with multiple nodes, the JAAS configuration file has to be created on all cluster nodes.
+When using a ZooKeeper cluster with multiple nodes, the JAAS configuration file has to be created on all cluster nodes.
 
 JAAS is configured using contexts.
 Separate parts such as the server and client are always configured with a separate _context_.
@@ -23,7 +23,7 @@ ContextName {
 };
 ----
 
-SASL Authentication is configured separately for server-to-server communication (communication between {Zookeeper} instances) and client-to-server communication (communication between Kafka and {Zookeeper}). Server-to-server authentication is relevant only for {Zookeeper} clusters with multiple nodes.
+SASL Authentication is configured separately for server-to-server communication (communication between ZooKeeper instances) and client-to-server communication (communication between Kafka and ZooKeeper). Server-to-server authentication is relevant only for ZooKeeper clusters with multiple nodes.
 
 .Server-to-Server authentication
 
@@ -34,7 +34,7 @@ For server-to-server authentication, the JAAS configuration file contains two pa
 
 When using DIGEST-MD5 SASL mechanism, the `QuorumServer` context is used to configure the authentication server.
 It must contain all the usernames to be allowed to connect together with their passwords in an unencrypted form.
-The second context, `QuorumLearner`, has to be configured for the client which is built into {Zookeeper}.
+The second context, `QuorumLearner`, has to be configured for the client which is built into ZooKeeper.
 It also contains the password in an unencrypted form.
 An example of the JAAS configuration file for DIGEST-MD5 mechanism can be found below:
 
@@ -52,7 +52,7 @@ QuorumLearner {
 };
 ----
 
-In addition to the JAAS configuration file, you must enable the server-to-server authentication in the regular {Zookeeper} configuration file by specifying the following options:
+In addition to the JAAS configuration file, you must enable the server-to-server authentication in the regular ZooKeeper configuration file by specifying the following options:
 
 [source]
 ----
@@ -64,7 +64,7 @@ quorum.auth.server.loginContext=QuorumServer
 quorum.cnxn.threads.size=20
 ----
 
-Use the `KAFKA_OPTS` environment variable to pass the JAAS configuration file to the {Zookeeper} server as a Java property:
+Use the `KAFKA_OPTS` environment variable to pass the JAAS configuration file to the ZooKeeper server as a Java property:
 
 [source]
 ----
@@ -73,14 +73,14 @@ export KAFKA_OPTS="-Djava.security.auth.login.config=/opt/kafka/config/zookeeper
 ----
 
 For more information about server-to-server authentication, see
-link:https://cwiki.apache.org/confluence/display/ZOOKEEPER/Server-Server+mutual+authentication[{Zookeeper} wiki^].
+link:https://cwiki.apache.org/confluence/display/ZOOKEEPER/Server-Server+mutual+authentication[ZooKeeper wiki^].
 
 .Client-to-Server authentication
 
 Client-to-server authentication is configured in the same JAAS file as the server-to-server authentication.
 However, unlike the server-to-server authentication, it contains only the server configuration.
 The client part of the configuration has to be done in the client.
-For information on how to configure a Kafka broker to connect to {Zookeeper} using authentication, see the xref:assembly-kafka-zookeeper-authentication-{context}[Kafka installation] section.
+For information on how to configure a Kafka broker to connect to ZooKeeper using authentication, see the xref:assembly-kafka-zookeeper-authentication-{context}[Kafka installation] section.
 
 Add the Server context to the JAAS configuration file to configure client-to-server authentication.
 For DIGEST-MD5 mechanism it configures all usernames and passwords:
@@ -95,7 +95,7 @@ Server {
 };
 ----
 
-After configuring the JAAS context, enable the client-to-server authentication in the {Zookeeper} configuration file by adding the following line:
+After configuring the JAAS context, enable the client-to-server authentication in the ZooKeeper configuration file by adding the following line:
 
 [source]
 ----
@@ -105,9 +105,9 @@ authProvider.2=org.apache.zookeeper.server.auth.SASLAuthenticationProvider
 authProvider.3=org.apache.zookeeper.server.auth.SASLAuthenticationProvider
 ----
 
-You must add the `authProvider._<ID>_` property for every server that is part of the {Zookeeper} cluster.
+You must add the `authProvider._<ID>_` property for every server that is part of the ZooKeeper cluster.
 
-Use the `KAFKA_OPTS` environment variable to pass the JAAS configuration file to the {Zookeeper} server as a Java property:
+Use the `KAFKA_OPTS` environment variable to pass the JAAS configuration file to the ZooKeeper server as a Java property:
 
 [source]
 ----
@@ -115,4 +115,4 @@ su - kafka
 export KAFKA_OPTS="-Djava.security.auth.login.config=/opt/kafka/config/zookeeper-jaas.conf"; /opt/kafka/bin/zookeeper-server-start.sh -daemon /opt/kafka/config/zookeeper.properties
 ----
 
-For more information about configuring {Zookeeper} authentication in Kafka brokers, see xref:assembly-kafka-zookeeper-authentication-{context}[].
+For more information about configuring ZooKeeper authentication in Kafka brokers, see xref:assembly-kafka-zookeeper-authentication-{context}[].

--- a/books/con-zookeeper-tls.adoc
+++ b/books/con-zookeeper-tls.adoc
@@ -6,4 +6,4 @@
 
 = TLS
 
-The version of Zookeeper which is part of AMQ Streams currently does not support TLS for encryption or authentication.
+The version of {Zookeeper} which is part of AMQ Streams currently does not support TLS for encryption or authentication.

--- a/books/con-zookeeper-tls.adoc
+++ b/books/con-zookeeper-tls.adoc
@@ -6,4 +6,4 @@
 
 = TLS
 
-The version of {Zookeeper} which is part of AMQ Streams currently does not support TLS for encryption or authentication.
+The version of ZooKeeper which is part of AMQ Streams currently does not support TLS for encryption or authentication.

--- a/books/proc-configuring-amq-streams.adoc
+++ b/books/proc-configuring-amq-streams.adoc
@@ -12,10 +12,10 @@
 
 .Procedure
 
-. Open {Zookeeper} and Kafka broker configuration files in a text editor. 
+. Open ZooKeeper and Kafka broker configuration files in a text editor. 
 The configuration files are located at :
 +
-{Zookeeper}:: `/opt/kafka/config/zookeeper.properties`
+ZooKeeper:: `/opt/kafka/config/zookeeper.properties`
 Kafka:: `/opt/kafka/config/server.properties`
 
 . Edit the configuration options.
@@ -39,6 +39,6 @@ sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule require
 
 . Save the changes
 
-. Restart the {Zookeeper} or Kafka broker
+. Restart the ZooKeeper or Kafka broker
 
 . Repeat this procedure on all the nodes of the cluster.

--- a/books/proc-configuring-amq-streams.adoc
+++ b/books/proc-configuring-amq-streams.adoc
@@ -12,10 +12,10 @@
 
 .Procedure
 
-. Open Zookeeper and Kafka broker configuration files in a text editor. 
+. Open {Zookeeper} and Kafka broker configuration files in a text editor. 
 The configuration files are located at :
 +
-Zookeeper:: `/opt/kafka/config/zookeeper.properties`
+{Zookeeper}:: `/opt/kafka/config/zookeeper.properties`
 Kafka:: `/opt/kafka/config/server.properties`
 
 . Edit the configuration options.
@@ -39,6 +39,6 @@ sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule require
 
 . Save the changes
 
-. Restart the Zookeeper or Kafka broker
+. Restart the {Zookeeper} or Kafka broker
 
 . Repeat this procedure on all the nodes of the cluster.

--- a/books/proc-creating-a-topic.adoc
+++ b/books/proc-creating-a-topic.adoc
@@ -16,7 +16,7 @@ The `kafka-topics.sh` tool can be used to manage topics.
 .Creating a topic
 
 . Create a topic using the `kafka-topics.sh` utility and specify the following:
-{Zookeeper} URL in the `--zookeeper` option.
+ZooKeeper URL in the `--zookeeper` option.
 The new topic to be created in the `--create` option.
 Topic name in the `--topic` option.
 The number of partitions in the `--partitions` option.
@@ -26,7 +26,7 @@ You can also override some of the default topic configuration options using the 
 This option can be used multiple times to override different options.
 +
 [source,shell,subs="+quotes,attributes"]
-bin/kafka-topics.sh --zookeeper _<{Zookeeper}Address>_ --create --topic _<TopicName>_ --partitions _<NumberOfPartitions>_ --replication-factor _<ReplicationFactor>_ --config _<Option1>_=_<Value1>_ --config _<Option2>_=_<Value2>_
+bin/kafka-topics.sh --zookeeper _<ZooKeeperAddress>_ --create --topic _<TopicName>_ --partitions _<NumberOfPartitions>_ --replication-factor _<ReplicationFactor>_ --config _<Option1>_=_<Value1>_ --config _<Option2>_=_<Value2>_
 +
 .Example of the command to create a topic named `mytopic`
 [source,shell,subs=+quotes]
@@ -35,7 +35,7 @@ bin/kafka-topics.sh --zookeeper zoo1.my-domain.com:2181 --create --topic mytopic
 . Verify that the topic exists using `kafka-topics.sh`.
 +
 [source,shell,subs="+quotes,attributes"]
-bin/kafka-topics.sh --zookeeper _<{Zookeeper}Address>_ --describe --topic _<TopicName>_
+bin/kafka-topics.sh --zookeeper _<ZooKeeperAddress>_ --describe --topic _<TopicName>_
 +
 .Example of the command to describe a topic named `mytopic`
 [source,shell,subs=+quotes]

--- a/books/proc-creating-a-topic.adoc
+++ b/books/proc-creating-a-topic.adoc
@@ -16,7 +16,7 @@ The `kafka-topics.sh` tool can be used to manage topics.
 .Creating a topic
 
 . Create a topic using the `kafka-topics.sh` utility and specify the following:
-Zookeeper URL in the `--zookeeper` option.
+{Zookeeper} URL in the `--zookeeper` option.
 The new topic to be created in the `--create` option.
 Topic name in the `--topic` option.
 The number of partitions in the `--partitions` option.
@@ -25,8 +25,8 @@ Replication factor in the `--replication-factor` option.
 You can also override some of the default topic configuration options using the option `--config`.
 This option can be used multiple times to override different options.
 +
-[source,shell,subs=+quotes]
-bin/kafka-topics.sh --zookeeper _<ZookeeperAddress>_ --create --topic _<TopicName>_ --partitions _<NumberOfPartitions>_ --replication-factor _<ReplicationFactor>_ --config _<Option1>_=_<Value1>_ --config _<Option2>_=_<Value2>_
+[source,shell,subs="+quotes,attributes"]
+bin/kafka-topics.sh --zookeeper _<{Zookeeper}Address>_ --create --topic _<TopicName>_ --partitions _<NumberOfPartitions>_ --replication-factor _<ReplicationFactor>_ --config _<Option1>_=_<Value1>_ --config _<Option2>_=_<Value2>_
 +
 .Example of the command to create a topic named `mytopic`
 [source,shell,subs=+quotes]
@@ -34,8 +34,8 @@ bin/kafka-topics.sh --zookeeper zoo1.my-domain.com:2181 --create --topic mytopic
 
 . Verify that the topic exists using `kafka-topics.sh`.
 +
-[source,shell,subs=+quotes]
-bin/kafka-topics.sh --zookeeper  _<ZookeeperAddress>_ --describe --topic _<TopicName>_
+[source,shell,subs="+quotes,attributes"]
+bin/kafka-topics.sh --zookeeper _<{Zookeeper}Address>_ --describe --topic _<TopicName>_
 +
 .Example of the command to describe a topic named `mytopic`
 [source,shell,subs=+quotes]

--- a/books/proc-deleting-a-topic.adoc
+++ b/books/proc-deleting-a-topic.adoc
@@ -18,12 +18,12 @@ The `kafka-topics.sh` tool can be used to manage topics.
 
 . Delete a topic using the `kafka-topics.sh` utility.
 +
-* Specify the Zookeeper URL in the `--zookeeper` option.
+* Specify the {Zookeeper} URL in the `--zookeeper` option.
 * Use `--delete` option to specify that an existing topic should be deleted.
 * Topic name has to be specified in the `--topic` option.
 +
-[source,shell,subs=+quotes]
-bin/kafka-topics.sh --zookeeper  _<ZookeeperAddress>_ --delete --topic _<TopicName>_
+[source,shell,subs="+quotes,attributes"]
+bin/kafka-topics.sh --zookeeper  _<{Zookeeper}Address>_ --delete --topic _<TopicName>_
 +
 .Example of the command to create a topic named `mytopic`
 [source,shell,subs=+quotes]
@@ -31,8 +31,8 @@ bin/kafka-topics.sh --zookeeper zoo1.my-domain.com:2181 --delete --topic mytopic
 
 . Verify that the topic was deleted using `kafka-topics.sh`.
 +
-[source,shell,subs=+quotes]
-bin/kafka-topics.sh --zookeeper  _<ZookeeperAddress>_ --list
+[source,shell,subs="+quotes,attributes"]
+bin/kafka-topics.sh --zookeeper  _<{Zookeeper}Address>_ --list
 +
 .Example of the command to list all topics
 [source,shell,subs=+quotes]

--- a/books/proc-deleting-a-topic.adoc
+++ b/books/proc-deleting-a-topic.adoc
@@ -18,12 +18,12 @@ The `kafka-topics.sh` tool can be used to manage topics.
 
 . Delete a topic using the `kafka-topics.sh` utility.
 +
-* Specify the {Zookeeper} URL in the `--zookeeper` option.
+* Specify the ZooKeeper URL in the `--zookeeper` option.
 * Use `--delete` option to specify that an existing topic should be deleted.
 * Topic name has to be specified in the `--topic` option.
 +
 [source,shell,subs="+quotes,attributes"]
-bin/kafka-topics.sh --zookeeper  _<{Zookeeper}Address>_ --delete --topic _<TopicName>_
+bin/kafka-topics.sh --zookeeper  _<ZooKeeperAddress>_ --delete --topic _<TopicName>_
 +
 .Example of the command to create a topic named `mytopic`
 [source,shell,subs=+quotes]
@@ -32,7 +32,7 @@ bin/kafka-topics.sh --zookeeper zoo1.my-domain.com:2181 --delete --topic mytopic
 . Verify that the topic was deleted using `kafka-topics.sh`.
 +
 [source,shell,subs="+quotes,attributes"]
-bin/kafka-topics.sh --zookeeper  _<{Zookeeper}Address>_ --list
+bin/kafka-topics.sh --zookeeper  _<ZooKeeperAddress>_ --list
 +
 .Example of the command to list all topics
 [source,shell,subs=+quotes]

--- a/books/proc-describing-a-topic.adoc
+++ b/books/proc-describing-a-topic.adoc
@@ -18,13 +18,13 @@ The `kafka-topics.sh` tool can be used to list and describe topics.
 
 . Describe a topic using the `kafka-topics.sh` utility.
 +
-* Specify the {Zookeeper} URL in the `--zookeeper` option.
+* Specify the ZooKeeper URL in the `--zookeeper` option.
 * Use `--describe` option to specify that you want to describe a topic.
 * Topic name has to be specified in the `--topic` option.
 * When the `--topic` option is omitted, it will describe all available topics.
 +
 [source,shell,subs="+quotes,attributes"]
-bin/kafka-topics.sh --zookeeper  _<{Zookeeper}Address>_ --describe --topic _<TopicName>_
+bin/kafka-topics.sh --zookeeper  _<ZooKeeperAddress>_ --describe --topic _<TopicName>_
 +
 .Example of the command to describe a topic named `mytopic`
 [source,shell,subs=+quotes]

--- a/books/proc-describing-a-topic.adoc
+++ b/books/proc-describing-a-topic.adoc
@@ -18,13 +18,13 @@ The `kafka-topics.sh` tool can be used to list and describe topics.
 
 . Describe a topic using the `kafka-topics.sh` utility.
 +
-* Specify the Zookeeper URL in the `--zookeeper` option.
+* Specify the {Zookeeper} URL in the `--zookeeper` option.
 * Use `--describe` option to specify that you want to describe a topic.
 * Topic name has to be specified in the `--topic` option.
 * When the `--topic` option is omitted, it will describe all available topics.
 +
-[source,shell,subs=+quotes]
-bin/kafka-topics.sh --zookeeper  _<ZookeeperAddress>_ --describe --topic _<TopicName>_
+[source,shell,subs="+quotes,attributes"]
+bin/kafka-topics.sh --zookeeper  _<{Zookeeper}Address>_ --describe --topic _<TopicName>_
 +
 .Example of the command to describe a topic named `mytopic`
 [source,shell,subs=+quotes]

--- a/books/proc-installing-amq-streams.adoc
+++ b/books/proc-installing-amq-streams.adoc
@@ -56,7 +56,7 @@ rm -r /tmp/kafka
 sudo chown -R kafka:kafka /opt/kafka
 ----
 
-. Create directory `/var/lib/zookeeper` for storing {Zookeeper} data and set its ownership to the `kafka` user.
+. Create directory `/var/lib/zookeeper` for storing ZooKeeper data and set its ownership to the `kafka` user.
 +
 [source,shell,subs=+quotes]
 ----

--- a/books/proc-installing-amq-streams.adoc
+++ b/books/proc-installing-amq-streams.adoc
@@ -56,7 +56,7 @@ rm -r /tmp/kafka
 sudo chown -R kafka:kafka /opt/kafka
 ----
 
-. Create directory `/var/lib/zookeeper` for storing Zookeeper data and set its ownership to the `kafka` user.
+. Create directory `/var/lib/zookeeper` for storing {Zookeeper} data and set its ownership to the `kafka` user.
 +
 [source,shell,subs=+quotes]
 ----

--- a/books/proc-kafka-adding-scram-users.adoc
+++ b/books/proc-kafka-adding-scram-users.adoc
@@ -18,7 +18,7 @@ This procedure describes how to add new users for authentication using SASL SCRA
 * Use the `kafka-configs.sh` tool to add new SASL SCRAM users.
 +
 [source,shell,subs="+quotes,attributes"]
-bin/kafka-configs.sh --zookeeper _<{Zookeeper}Address>_ --alter --add-config 'SCRAM-SHA-512=[password=_<Password>_]' --entity-type users --entity-name _<Username>_
+bin/kafka-configs.sh --zookeeper _<ZooKeeperAddress>_ --alter --add-config 'SCRAM-SHA-512=[password=_<Password>_]' --entity-type users --entity-name _<Username>_
 +
 For example:
 +

--- a/books/proc-kafka-adding-scram-users.adoc
+++ b/books/proc-kafka-adding-scram-users.adoc
@@ -17,8 +17,8 @@ This procedure describes how to add new users for authentication using SASL SCRA
 
 * Use the `kafka-configs.sh` tool to add new SASL SCRAM users.
 +
-[source,subs=+quotes]
-bin/kafka-configs.sh --zookeeper _<ZookeeperAddress>_ --alter --add-config 'SCRAM-SHA-512=[password=_<Password>_]' --entity-type users --entity-name _<Username>_
+[source,shell,subs="+quotes,attributes"]
+bin/kafka-configs.sh --zookeeper _<{Zookeeper}Address>_ --alter --add-config 'SCRAM-SHA-512=[password=_<Password>_]' --entity-type users --entity-name _<Username>_
 +
 For example:
 +

--- a/books/proc-kafka-authorization-add-rules.adoc
+++ b/books/proc-kafka-authorization-add-rules.adoc
@@ -10,7 +10,7 @@
 
 This procedure describes how to add ACL rules when using the `SimpleAclAuthorizer` plugin in Kafka brokers.
 
-Rules are added using the `kafka-acls.sh` utility and stored in {Zookeeper}.
+Rules are added using the `kafka-acls.sh` utility and stored in ZooKeeper.
 
 .Prerequisites
 

--- a/books/proc-kafka-authorization-add-rules.adoc
+++ b/books/proc-kafka-authorization-add-rules.adoc
@@ -10,7 +10,7 @@
 
 This procedure describes how to add ACL rules when using the `SimpleAclAuthorizer` plugin in Kafka brokers.
 
-Rules are added using the `kafka-acls.sh` utility and stored in Zookeeper.
+Rules are added using the `kafka-acls.sh` utility and stored in {Zookeeper}.
 
 .Prerequisites
 

--- a/books/proc-kafka-deleting-scram-users.adoc
+++ b/books/proc-kafka-deleting-scram-users.adoc
@@ -17,8 +17,8 @@ This procedure describes how to remove users when using SASL SCRAM authenticatio
 
 * Use the `kafka-configs.sh` tool to delete SASL SCRAM users.
 +
-[source,subs=+quotes]
-bin/kafka-configs.sh --zookeeper _<ZookeeperAddress>_ --alter --delete-config 'SCRAM-SHA-512' --entity-type users --entity-name _<Username>_
+[source,shell,subs="+quotes,attributes"]
+bin/kafka-configs.sh --zookeeper _<{Zookeeper}Address>_ --alter --delete-config 'SCRAM-SHA-512' --entity-type users --entity-name _<Username>_
 +
 For example:
 +

--- a/books/proc-kafka-deleting-scram-users.adoc
+++ b/books/proc-kafka-deleting-scram-users.adoc
@@ -18,7 +18,7 @@ This procedure describes how to remove users when using SASL SCRAM authenticatio
 * Use the `kafka-configs.sh` tool to delete SASL SCRAM users.
 +
 [source,shell,subs="+quotes,attributes"]
-bin/kafka-configs.sh --zookeeper _<{Zookeeper}Address>_ --alter --delete-config 'SCRAM-SHA-512' --entity-type users --entity-name _<Username>_
+bin/kafka-configs.sh --zookeeper _<ZooKeeperAddress>_ --alter --delete-config 'SCRAM-SHA-512' --entity-type users --entity-name _<Username>_
 +
 For example:
 +

--- a/books/proc-kafka-enable-zookeeper-auth.adoc
+++ b/books/proc-kafka-enable-zookeeper-auth.adoc
@@ -4,13 +4,13 @@
 
 [id='proc-kafka-enable-zookeeper-auth-{context}']
 
-= Enabling Zookeeper authentication
+= Enabling {Zookeeper} authentication
 
-This procedure describes how to enable authentication using the SASL DIGEST-MD5 mechanism when connecting to Zookeeper.
+This procedure describes how to enable authentication using the SASL DIGEST-MD5 mechanism when connecting to {Zookeeper}.
 
 .Prerequisites
 
-* Client-to-server authentication is xref:assembly-kafka-zookeeper-authentication-{context}[enabled] in Zookeeper
+* Client-to-server authentication is xref:assembly-kafka-zookeeper-authentication-{context}[enabled] in {Zookeeper}
 
 .Enabling SASL DIGEST-MD5 authentication
 
@@ -25,7 +25,7 @@ Client {
 };
 ----
 +
-The username and password should be the same as configured in Zookeeper.
+The username and password should be the same as configured in {Zookeeper}.
 +
 Following example shows the `Client` context:
 +
@@ -49,4 +49,4 @@ export KAFKA_OPTS="-Djava.security.auth.login.config=/opt/kafka/config/jaas.conf
 
 .Additional resources
 
-* For more information about configuring client-to-server authentication in Zookeeper, see xref:assembly-configuring-zookeeper-authentication-{context}[].
+* For more information about configuring client-to-server authentication in {Zookeeper}, see xref:assembly-configuring-zookeeper-authentication-{context}[].

--- a/books/proc-kafka-enable-zookeeper-auth.adoc
+++ b/books/proc-kafka-enable-zookeeper-auth.adoc
@@ -4,13 +4,13 @@
 
 [id='proc-kafka-enable-zookeeper-auth-{context}']
 
-= Enabling {Zookeeper} authentication
+= Enabling ZooKeeper authentication
 
-This procedure describes how to enable authentication using the SASL DIGEST-MD5 mechanism when connecting to {Zookeeper}.
+This procedure describes how to enable authentication using the SASL DIGEST-MD5 mechanism when connecting to ZooKeeper.
 
 .Prerequisites
 
-* Client-to-server authentication is xref:assembly-kafka-zookeeper-authentication-{context}[enabled] in {Zookeeper}
+* Client-to-server authentication is xref:assembly-kafka-zookeeper-authentication-{context}[enabled] in ZooKeeper
 
 .Enabling SASL DIGEST-MD5 authentication
 
@@ -25,7 +25,7 @@ Client {
 };
 ----
 +
-The username and password should be the same as configured in {Zookeeper}.
+The username and password should be the same as configured in ZooKeeper.
 +
 Following example shows the `Client` context:
 +
@@ -49,4 +49,4 @@ export KAFKA_OPTS="-Djava.security.auth.login.config=/opt/kafka/config/jaas.conf
 
 .Additional resources
 
-* For more information about configuring client-to-server authentication in {Zookeeper}, see xref:assembly-configuring-zookeeper-authentication-{context}[].
+* For more information about configuring client-to-server authentication in ZooKeeper, see xref:assembly-configuring-zookeeper-authentication-{context}[].

--- a/books/proc-kafka-enabling-zookeeper-acls.adoc
+++ b/books/proc-kafka-enabling-zookeeper-acls.adoc
@@ -4,18 +4,18 @@
 
 [id='proc-kafka-enabling-zookeeper-acls-{context}']
 
-= Enabling {Zookeeper} ACLs for a new Kafka cluster
+= Enabling ZooKeeper ACLs for a new Kafka cluster
 
-This procedure describes how to enable {Zookeeper} ACLs in Kafka configuration for a new Kafka cluster.
+This procedure describes how to enable ZooKeeper ACLs in Kafka configuration for a new Kafka cluster.
 Use this procedure only before the first start of the Kafka cluster.
-For enabling {Zookeeper} ACLs in a cluster that is already running, see xref:proc-kafka-migrating-zookeeper-acls-{context}[].
+For enabling ZooKeeper ACLs in a cluster that is already running, see xref:proc-kafka-migrating-zookeeper-acls-{context}[].
 
 .Prerequisites
 
 * AMQ Streams is xref:proc-installing-amq-streams-{context}[installed] on all hosts which will be used as Kafka brokers.
-* {Zookeeper} cluster is xref:proc-running-multinode-zookeeper-cluster-{context}[configured and running].
-* Client-to-server authentication is xref:proc-zookeeper-enable-client-to-server-auth-digest-md5-{context}[enabled] in {Zookeeper}.
-* {Zookeeper} authentication is xref:proc-kafka-enable-zookeeper-auth-{context}[enabled] in the Kafka brokers.
+* ZooKeeper cluster is xref:proc-running-multinode-zookeeper-cluster-{context}[configured and running].
+* Client-to-server authentication is xref:proc-zookeeper-enable-client-to-server-auth-digest-md5-{context}[enabled] in ZooKeeper.
+* ZooKeeper authentication is xref:proc-kafka-enable-zookeeper-auth-{context}[enabled] in the Kafka brokers.
 * Kafka brokers have not yet been started.
 
 .Procedure

--- a/books/proc-kafka-enabling-zookeeper-acls.adoc
+++ b/books/proc-kafka-enabling-zookeeper-acls.adoc
@@ -4,18 +4,18 @@
 
 [id='proc-kafka-enabling-zookeeper-acls-{context}']
 
-= Enabling Zookeeper ACLs for a new Kafka cluster
+= Enabling {Zookeeper} ACLs for a new Kafka cluster
 
-This procedure describes how to enable Zookeeper ACLs in Kafka configuration for a new Kafka cluster.
+This procedure describes how to enable {Zookeeper} ACLs in Kafka configuration for a new Kafka cluster.
 Use this procedure only before the first start of the Kafka cluster.
-For enabling Zookeeper ACLs in a cluster that is already running, see xref:proc-kafka-migrating-zookeeper-acls-{context}[].
+For enabling {Zookeeper} ACLs in a cluster that is already running, see xref:proc-kafka-migrating-zookeeper-acls-{context}[].
 
 .Prerequisites
 
 * AMQ Streams is xref:proc-installing-amq-streams-{context}[installed] on all hosts which will be used as Kafka brokers.
-* Zookeeper cluster is xref:proc-running-multinode-zookeeper-cluster-{context}[configured and running].
-* Client-to-server authentication is xref:proc-zookeeper-enable-client-to-server-auth-digest-md5-{context}[enabled] in Zookeeper.
-* Zookeeper authentication is xref:proc-kafka-enable-zookeeper-auth-{context}[enabled] in the Kafka brokers.
+* {Zookeeper} cluster is xref:proc-running-multinode-zookeeper-cluster-{context}[configured and running].
+* Client-to-server authentication is xref:proc-zookeeper-enable-client-to-server-auth-digest-md5-{context}[enabled] in {Zookeeper}.
+* {Zookeeper} authentication is xref:proc-kafka-enable-zookeeper-auth-{context}[enabled] in the Kafka brokers.
 * Kafka brokers have not yet been started.
 
 .Procedure

--- a/books/proc-kafka-migrating-zookeeper-acls.adoc
+++ b/books/proc-kafka-migrating-zookeeper-acls.adoc
@@ -4,17 +4,17 @@
 
 [id='proc-kafka-migrating-zookeeper-acls-{context}']
 
-= Enabling Zookeeper ACLs in an existing Kafka cluster
+= Enabling {Zookeeper} ACLs in an existing Kafka cluster
 
-This procedure describes how to enable Zookeeper ACLs in Kafka configuration for a Kafka cluster that is running.
-Use the `zookeeper-security-migration.sh` tool to set Zookeeper ACLs on all existing `znodes`.
+This procedure describes how to enable {Zookeeper} ACLs in Kafka configuration for a Kafka cluster that is running.
+Use the `zookeeper-security-migration.sh` tool to set {Zookeeper} ACLs on all existing `znodes`.
 The `zookeeper-security-migration.sh` is available as part of AMQ Streams, and can be found in the `bin` directory.
 
 .Prerequisites
 
 * Kafka cluster is xref:proc-running-multinode-kafka-cluster-{context}[configured and running].
 
-.Enabling the Zookeeper ACLs
+.Enabling the {Zookeeper} ACLs
 
 . Edit the `/opt/kafka/config/server.properties` Kafka configuration file to set the `zookeeper.set.acl` field to `true` on all cluster nodes.
 +
@@ -25,13 +25,13 @@ zookeeper.set.acl=true
 
 . Restart all Kafka brokers one by one.
 
-. Set the ACLs on all existing Zookeeper `znodes` using the `zookeeper-security-migration.sh` tool.
+. Set the ACLs on all existing {Zookeeper} `znodes` using the `zookeeper-security-migration.sh` tool.
 +
-[source]
+[source,subs="+quotes,attributes"]
 ----
 su - kafka
 cd /opt/kafka
-KAFKA_OPTS="-Djava.security.auth.login.config=./config/jaas.conf"; ./bin/zookeeper-security-migration.sh --zookeeper.acl=secure --zookeeper.connect=_<ZookeeperURL>_
+KAFKA_OPTS="-Djava.security.auth.login.config=./config/jaas.conf"; ./bin/zookeeper-security-migration.sh --zookeeper.acl=secure --zookeeper.connect=_<{Zookeeper}URL>_
 exit
 ----
 +

--- a/books/proc-kafka-migrating-zookeeper-acls.adoc
+++ b/books/proc-kafka-migrating-zookeeper-acls.adoc
@@ -4,17 +4,17 @@
 
 [id='proc-kafka-migrating-zookeeper-acls-{context}']
 
-= Enabling {Zookeeper} ACLs in an existing Kafka cluster
+= Enabling ZooKeeper ACLs in an existing Kafka cluster
 
-This procedure describes how to enable {Zookeeper} ACLs in Kafka configuration for a Kafka cluster that is running.
-Use the `zookeeper-security-migration.sh` tool to set {Zookeeper} ACLs on all existing `znodes`.
+This procedure describes how to enable ZooKeeper ACLs in Kafka configuration for a Kafka cluster that is running.
+Use the `zookeeper-security-migration.sh` tool to set ZooKeeper ACLs on all existing `znodes`.
 The `zookeeper-security-migration.sh` is available as part of AMQ Streams, and can be found in the `bin` directory.
 
 .Prerequisites
 
 * Kafka cluster is xref:proc-running-multinode-kafka-cluster-{context}[configured and running].
 
-.Enabling the {Zookeeper} ACLs
+.Enabling the ZooKeeper ACLs
 
 . Edit the `/opt/kafka/config/server.properties` Kafka configuration file to set the `zookeeper.set.acl` field to `true` on all cluster nodes.
 +
@@ -25,13 +25,13 @@ zookeeper.set.acl=true
 
 . Restart all Kafka brokers one by one.
 
-. Set the ACLs on all existing {Zookeeper} `znodes` using the `zookeeper-security-migration.sh` tool.
+. Set the ACLs on all existing ZooKeeper `znodes` using the `zookeeper-security-migration.sh` tool.
 +
 [source,subs="+quotes,attributes"]
 ----
 su - kafka
 cd /opt/kafka
-KAFKA_OPTS="-Djava.security.auth.login.config=./config/jaas.conf"; ./bin/zookeeper-security-migration.sh --zookeeper.acl=secure --zookeeper.connect=_<{Zookeeper}URL>_
+KAFKA_OPTS="-Djava.security.auth.login.config=./config/jaas.conf"; ./bin/zookeeper-security-migration.sh --zookeeper.acl=secure --zookeeper.connect=_<ZooKeeperURL>_
 exit
 ----
 +

--- a/books/proc-modifying-a-topic.adoc
+++ b/books/proc-modifying-a-topic.adoc
@@ -18,12 +18,12 @@ The `kafka-configs.sh` tool can be used to modify topic configurations.
 
 . Use the `kafka-configs.sh` tool to get the current configuration.
 +
-* Specify the Zookeeper URL in the `--zookeeper` option.
+* Specify the {Zookeeper} URL in the `--zookeeper` option.
 * Set the `--entity-type` as `topic` and `--entity-name` to the name of your topic.
 * Use `--describe` option to get the current configuration.
 +
-[source,shell,subs=+quotes]
-bin/kafka-configs.sh --zookeeper _<ZookeeperAddress>_ --entity-type topics --entity-name _<TopicName>_ --describe
+[source,shell,subs="+quotes,attributes"]
+bin/kafka-configs.sh --zookeeper _<{Zookeeper}Address>_ --entity-type topics --entity-name _<TopicName>_ --describe
 +
 .Example of the command to get configuration of a topic named `mytopic`
 [source,shell,subs=+quotes]
@@ -31,13 +31,13 @@ bin/kafka-configs.sh --zookeeper zoo1.my-domain.com:2181 --entity-type topics --
 
 . Use the `kafka-configs.sh` tool to change the configuration.
 +
-* Specify the Zookeeper URL in the `--zookeeper` options.
+* Specify the {Zookeeper} URL in the `--zookeeper` options.
 * Set the `--entity-type` as `topic` and `--entity-name` to the name of your topic.
 * Use `--alter` option to modify the current configuration.
 * Specify the options you want to add or change in the option `--add-config`.
 +
-[source,shell,subs=+quotes]
-bin/kafka-configs.sh --zookeeper _<ZookeeperAddress>_ --entity-type topics --entity-name _<TopicName>_ --alter --add-config _<Option>_=_<Value>_
+[source,shell,subs="+quotes,attributes"]
+bin/kafka-configs.sh --zookeeper _<{Zookeeper}Address>_ --entity-type topics --entity-name _<TopicName>_ --alter --add-config _<Option>_=_<Value>_
 +
 .Example of the command to change configuration of a topic named `mytopic`
 [source,shell,subs=+quotes]
@@ -45,13 +45,13 @@ bin/kafka-configs.sh --zookeeper zoo1.my-domain.com:2181 --entity-type topics --
 
 . Use the `kafka-configs.sh` tool to delete an existing configuration option.
 +
-* Specify the Zookeeper URL in the `--zookeeper` options.
+* Specify the {Zookeeper} URL in the `--zookeeper` options.
 * Set the `--entity-type` as `topic` and `--entity-name` to the name of your topic.
 * Use `--delete-config` option to remove existing configuration option.
 * Specify the options you want to remove in the option `--remove-config`.
 +
-[source,shell,subs=+quotes]
-bin/kafka-configs.sh --zookeeper _<ZookeeperAddress>_ --entity-type topics --entity-name _<TopicName>_ --alter --delete-config _<Option>_
+[source,shell,subs="+quotes,attributes"]
+bin/kafka-configs.sh --zookeeper _<{Zookeeper}Address>_ --entity-type topics --entity-name _<TopicName>_ --alter --delete-config _<Option>_
 +
 .Example of the command to change configuration of a topic named `mytopic`
 [source,shell,subs=+quotes]

--- a/books/proc-modifying-a-topic.adoc
+++ b/books/proc-modifying-a-topic.adoc
@@ -18,12 +18,12 @@ The `kafka-configs.sh` tool can be used to modify topic configurations.
 
 . Use the `kafka-configs.sh` tool to get the current configuration.
 +
-* Specify the {Zookeeper} URL in the `--zookeeper` option.
+* Specify the ZooKeeper URL in the `--zookeeper` option.
 * Set the `--entity-type` as `topic` and `--entity-name` to the name of your topic.
 * Use `--describe` option to get the current configuration.
 +
 [source,shell,subs="+quotes,attributes"]
-bin/kafka-configs.sh --zookeeper _<{Zookeeper}Address>_ --entity-type topics --entity-name _<TopicName>_ --describe
+bin/kafka-configs.sh --zookeeper _<ZooKeeperAddress>_ --entity-type topics --entity-name _<TopicName>_ --describe
 +
 .Example of the command to get configuration of a topic named `mytopic`
 [source,shell,subs=+quotes]
@@ -31,13 +31,13 @@ bin/kafka-configs.sh --zookeeper zoo1.my-domain.com:2181 --entity-type topics --
 
 . Use the `kafka-configs.sh` tool to change the configuration.
 +
-* Specify the {Zookeeper} URL in the `--zookeeper` options.
+* Specify the ZooKeeper URL in the `--zookeeper` options.
 * Set the `--entity-type` as `topic` and `--entity-name` to the name of your topic.
 * Use `--alter` option to modify the current configuration.
 * Specify the options you want to add or change in the option `--add-config`.
 +
 [source,shell,subs="+quotes,attributes"]
-bin/kafka-configs.sh --zookeeper _<{Zookeeper}Address>_ --entity-type topics --entity-name _<TopicName>_ --alter --add-config _<Option>_=_<Value>_
+bin/kafka-configs.sh --zookeeper _<ZooKeeperAddress>_ --entity-type topics --entity-name _<TopicName>_ --alter --add-config _<Option>_=_<Value>_
 +
 .Example of the command to change configuration of a topic named `mytopic`
 [source,shell,subs=+quotes]
@@ -45,13 +45,13 @@ bin/kafka-configs.sh --zookeeper zoo1.my-domain.com:2181 --entity-type topics --
 
 . Use the `kafka-configs.sh` tool to delete an existing configuration option.
 +
-* Specify the {Zookeeper} URL in the `--zookeeper` options.
+* Specify the ZooKeeper URL in the `--zookeeper` options.
 * Set the `--entity-type` as `topic` and `--entity-name` to the name of your topic.
 * Use `--delete-config` option to remove existing configuration option.
 * Specify the options you want to remove in the option `--remove-config`.
 +
 [source,shell,subs="+quotes,attributes"]
-bin/kafka-configs.sh --zookeeper _<{Zookeeper}Address>_ --entity-type topics --entity-name _<TopicName>_ --alter --delete-config _<Option>_
+bin/kafka-configs.sh --zookeeper _<ZooKeeperAddress>_ --entity-type topics --entity-name _<TopicName>_ --alter --delete-config _<Option>_
 +
 .Example of the command to change configuration of a topic named `mytopic`
 [source,shell,subs=+quotes]

--- a/books/proc-running-multinode-kafka-cluster.adoc
+++ b/books/proc-running-multinode-kafka-cluster.adoc
@@ -11,7 +11,7 @@ This procedure describes how to configure and run Kafka as a multi-node cluster.
 .Prerequisites
 
 * AMQ Streams is xref:proc-installing-amq-streams-{context}[installed] on all hosts which will be used as Kafka brokers.
-* A Zookeeper cluster is xref:proc-running-multinode-zookeeper-cluster-{context}[configured and running].
+* A {Zookeeper} cluster is xref:proc-running-multinode-zookeeper-cluster-{context}[configured and running].
 
 .Running the cluster
 
@@ -20,7 +20,7 @@ For each Kafka broker in your {ProductName} cluster:
 . Edit the `/opt/kafka/config/server.properties` Kafka configuration file as follows:
 +
 * Set the `broker.id` field to `0` for the first broker, `1` for the second broker, and so on.
-* Configure the details for connecting to Zookeeper in the `zookeeper.connect` option.
+* Configure the details for connecting to {Zookeeper} in the `zookeeper.connect` option.
 * Configure the Kafka listeners.
 * Set the directories where the commit logs should be stored in the `logs.dir` directory.
 +
@@ -54,8 +54,8 @@ jcmd | grep Kafka
 
 .Verifying the brokers
 
-Once all nodes of the clusters are up and running, verify that all nodes are members of the Kafka cluster by sending a `dump` command to one of the Zookeeper nodes using the `ncat` utility.
-The command prints all Kafka brokers registered in Zookeeper.
+Once all nodes of the clusters are up and running, verify that all nodes are members of the Kafka cluster by sending a `dump` command to one of the {Zookeeper} nodes using the `ncat` utility.
+The command prints all Kafka brokers registered in {Zookeeper}.
 
 . Use ncat stat to check the node status.
 +
@@ -68,7 +68,7 @@ The output should contain all Kafka brokers you just configured and started.
 +
 Example output from the `ncat` command for Kafka cluster with 3 nodes:
 +
-[source,plain,subs=+quotes]
+[source,plain,subs="+quotes,attributes"]
 ----
 SessionTracker dump:
 org.apache.zookeeper.server.quorum.LearnerSessionTracker@28848ab9
@@ -87,5 +87,5 @@ Sessions with Ephemerals (3):
 
 * For more information about installing AMQ Streams, see xref:proc-installing-amq-streams-{context}[].
 * For more information about configuring AMQ Streams, see xref:proc-configuring-amq-streams-{context}[].
-* For more information about running a Zookeeper cluster, see xref:proc-running-multinode-zookeeper-cluster-{context}[].
+* For more information about running a {Zookeeper} cluster, see xref:proc-running-multinode-zookeeper-cluster-{context}[].
 * For a complete list of supported Kafka broker configuration options, see xref:broker-configuration-parameters-{context}[].

--- a/books/proc-running-multinode-kafka-cluster.adoc
+++ b/books/proc-running-multinode-kafka-cluster.adoc
@@ -11,7 +11,7 @@ This procedure describes how to configure and run Kafka as a multi-node cluster.
 .Prerequisites
 
 * AMQ Streams is xref:proc-installing-amq-streams-{context}[installed] on all hosts which will be used as Kafka brokers.
-* A {Zookeeper} cluster is xref:proc-running-multinode-zookeeper-cluster-{context}[configured and running].
+* A ZooKeeper cluster is xref:proc-running-multinode-zookeeper-cluster-{context}[configured and running].
 
 .Running the cluster
 
@@ -20,7 +20,7 @@ For each Kafka broker in your {ProductName} cluster:
 . Edit the `/opt/kafka/config/server.properties` Kafka configuration file as follows:
 +
 * Set the `broker.id` field to `0` for the first broker, `1` for the second broker, and so on.
-* Configure the details for connecting to {Zookeeper} in the `zookeeper.connect` option.
+* Configure the details for connecting to ZooKeeper in the `zookeeper.connect` option.
 * Configure the Kafka listeners.
 * Set the directories where the commit logs should be stored in the `logs.dir` directory.
 +
@@ -54,8 +54,8 @@ jcmd | grep Kafka
 
 .Verifying the brokers
 
-Once all nodes of the clusters are up and running, verify that all nodes are members of the Kafka cluster by sending a `dump` command to one of the {Zookeeper} nodes using the `ncat` utility.
-The command prints all Kafka brokers registered in {Zookeeper}.
+Once all nodes of the clusters are up and running, verify that all nodes are members of the Kafka cluster by sending a `dump` command to one of the ZooKeeper nodes using the `ncat` utility.
+The command prints all Kafka brokers registered in ZooKeeper.
 
 . Use ncat stat to check the node status.
 +
@@ -87,5 +87,5 @@ Sessions with Ephemerals (3):
 
 * For more information about installing AMQ Streams, see xref:proc-installing-amq-streams-{context}[].
 * For more information about configuring AMQ Streams, see xref:proc-configuring-amq-streams-{context}[].
-* For more information about running a {Zookeeper} cluster, see xref:proc-running-multinode-zookeeper-cluster-{context}[].
+* For more information about running a ZooKeeper cluster, see xref:proc-running-multinode-zookeeper-cluster-{context}[].
 * For a complete list of supported Kafka broker configuration options, see xref:broker-configuration-parameters-{context}[].

--- a/books/proc-running-multinode-zookeeper-cluster.adoc
+++ b/books/proc-running-multinode-zookeeper-cluster.adoc
@@ -4,19 +4,20 @@
 
 [id='proc-running-multinode-zookeeper-cluster-{context}']
 
-= Running multi-node Zookeeper cluster
+= Running multi-node {Zookeeper} cluster
 
-This procedure will show you how to configure and run Zookeeper as a multi-node cluster.
+This procedure will show you how to configure and run {Zookeeper} as a multi-node cluster.
 
 .Prerequisites
 
-* AMQ Streams is installed on all hosts which will be used as Zookeeper cluster nodes.
+* AMQ Streams is installed on all hosts which will be used as {Zookeeper} cluster nodes.
 
 .Running the cluster
 
 . Create the `myid` file in `/var/lib/zookeeper/`.
-Enter ID `1` for the first Zookeeper node, `2` for the second Zookeeper node, and so on.
+Enter ID `1` for the first {Zookeeper} node, `2` for the second {Zookeeper} node, and so on.
 +
+[source,subs="+quotes,attributes"]
 ----
 su - kafka
 echo "_<NodeID>_" > /var/lib/zookeeper/myid
@@ -29,14 +30,14 @@ su - kafka
 echo "1" > /var/lib/zookeeper/myid
 ----
 
-. Edit the Zookeeper `/opt/kafka/config/zookeeper.properties` configuration file for the following:
+. Edit the {Zookeeper} `/opt/kafka/config/zookeeper.properties` configuration file for the following:
 +
 * Set the option `dataDir` to `/var/lib/zookeeper/`.
 + Configure the `initLimit` and `syncLimit` options.
-* Add a list of all Zookeeper nodes.
+* Add a list of all {Zookeeper} nodes.
 The list should include also the current node.
 +
-.Example configuration for a node of Zookeeper cluster with five members
+.Example configuration for a node of {Zookeeper} cluster with five members
 [source,ini]
 ----
 timeTick=2000
@@ -52,7 +53,7 @@ server.4=172.17.0.4:2888:3888
 server.5=172.17.0.5:2888:3888
 ----
 
-. Start Zookeeper with the default configuration file.
+. Start {Zookeeper} with the default configuration file.
 +
 [source,shell,subs=+quotes]
 ----
@@ -60,7 +61,7 @@ su - kafka
 /opt/kafka/bin/zookeeper-server-start.sh -daemon /opt/kafka/config/zookeeper.properties
 ----
 
-. Verify that the Zookeeper is running.
+. Verify that the {Zookeeper} is running.
 +
 [source,shell,subs=+quotes]
 ----
@@ -80,9 +81,9 @@ echo stat | ncat localhost 2181
 In the output you should see information that the node is either `leader` or `follower`.
 +
 .Example output from the `ncat` command
-[source,subs=+quotes]
+[source,subs="+quotes,attributes"]
 ----
-Zookeeper version: 3.4.13-2d71af4dbe22557fda74f9a9b4309b15a7487f03, built on 06/29/2018 00:39 GMT
+{Zookeeper} version: 3.4.13-2d71af4dbe22557fda74f9a9b4309b15a7487f03, built on 06/29/2018 00:39 GMT
 Clients:
  /0:0:0:0:0:0:0:1:59726[0](queued=0,recved=1,sent=0)
 

--- a/books/proc-running-multinode-zookeeper-cluster.adoc
+++ b/books/proc-running-multinode-zookeeper-cluster.adoc
@@ -4,18 +4,18 @@
 
 [id='proc-running-multinode-zookeeper-cluster-{context}']
 
-= Running multi-node {Zookeeper} cluster
+= Running multi-node ZooKeeper cluster
 
-This procedure will show you how to configure and run {Zookeeper} as a multi-node cluster.
+This procedure will show you how to configure and run ZooKeeper as a multi-node cluster.
 
 .Prerequisites
 
-* AMQ Streams is installed on all hosts which will be used as {Zookeeper} cluster nodes.
+* AMQ Streams is installed on all hosts which will be used as ZooKeeper cluster nodes.
 
 .Running the cluster
 
 . Create the `myid` file in `/var/lib/zookeeper/`.
-Enter ID `1` for the first {Zookeeper} node, `2` for the second {Zookeeper} node, and so on.
+Enter ID `1` for the first ZooKeeper node, `2` for the second ZooKeeper node, and so on.
 +
 [source,subs="+quotes,attributes"]
 ----
@@ -30,14 +30,14 @@ su - kafka
 echo "1" > /var/lib/zookeeper/myid
 ----
 
-. Edit the {Zookeeper} `/opt/kafka/config/zookeeper.properties` configuration file for the following:
+. Edit the ZooKeeper `/opt/kafka/config/zookeeper.properties` configuration file for the following:
 +
 * Set the option `dataDir` to `/var/lib/zookeeper/`.
 + Configure the `initLimit` and `syncLimit` options.
-* Add a list of all {Zookeeper} nodes.
+* Add a list of all ZooKeeper nodes.
 The list should include also the current node.
 +
-.Example configuration for a node of {Zookeeper} cluster with five members
+.Example configuration for a node of ZooKeeper cluster with five members
 [source,ini]
 ----
 timeTick=2000
@@ -53,7 +53,7 @@ server.4=172.17.0.4:2888:3888
 server.5=172.17.0.5:2888:3888
 ----
 
-. Start {Zookeeper} with the default configuration file.
+. Start ZooKeeper with the default configuration file.
 +
 [source,shell,subs=+quotes]
 ----
@@ -61,7 +61,7 @@ su - kafka
 /opt/kafka/bin/zookeeper-server-start.sh -daemon /opt/kafka/config/zookeeper.properties
 ----
 
-. Verify that the {Zookeeper} is running.
+. Verify that the ZooKeeper is running.
 +
 [source,shell,subs=+quotes]
 ----
@@ -83,7 +83,7 @@ In the output you should see information that the node is either `leader` or `fo
 .Example output from the `ncat` command
 [source,subs="+quotes,attributes"]
 ----
-{Zookeeper} version: 3.4.13-2d71af4dbe22557fda74f9a9b4309b15a7487f03, built on 06/29/2018 00:39 GMT
+ZooKeeper version: 3.4.13-2d71af4dbe22557fda74f9a9b4309b15a7487f03, built on 06/29/2018 00:39 GMT
 Clients:
  /0:0:0:0:0:0:0:1:59726[0](queued=0,recved=1,sent=0)
 

--- a/books/proc-running-single-node-amq-streams-cluster.adoc
+++ b/books/proc-running-single-node-amq-streams-cluster.adoc
@@ -6,8 +6,8 @@
 
 = Running single node AMQ Streams cluster
 
-This procedure will show you how to run a basic AMQ Streams cluster consisting of single {Zookeeper} and single Apache Kafka node both running on the same host.
-It is using the default configuration files for both {Zookeeper} and Kafka.
+This procedure will show you how to run a basic AMQ Streams cluster consisting of single ZooKeeper and single Apache Kafka node both running on the same host.
+It is using the default configuration files for both ZooKeeper and Kafka.
 
 WARNING: A single node AMQ Streams cluster does not provide reliability and high availability and is suitable only for development purposes.
 
@@ -17,7 +17,7 @@ WARNING: A single node AMQ Streams cluster does not provide reliability and high
 
 .Running the cluster
 
-. Edit the {Zookeeper} configuration file `/opt/kafka/config/zookeeper.properties`.
+. Edit the ZooKeeper configuration file `/opt/kafka/config/zookeeper.properties`.
 Set the `dataDir` option to `/var/lib/zookeeper/`.
 +
 [source,properties,subs=+quotes]
@@ -25,7 +25,7 @@ Set the `dataDir` option to `/var/lib/zookeeper/`.
 dataDir=/var/lib/zookeeper/
 ----
 
-. Start {Zookeeper}.
+. Start ZooKeeper.
 +
 [source,shell,subs=+quotes]
 ----
@@ -33,7 +33,7 @@ su - kafka
 /opt/kafka/bin/zookeeper-server-start.sh -daemon /opt/kafka/config/zookeeper.properties
 ----
 
-. Make sure that Apache {Zookeeper} is running.
+. Make sure that Apache ZooKeeper is running.
 +
 [source,shell,subs=+quotes]
 ----

--- a/books/proc-running-single-node-amq-streams-cluster.adoc
+++ b/books/proc-running-single-node-amq-streams-cluster.adoc
@@ -6,8 +6,8 @@
 
 = Running single node AMQ Streams cluster
 
-This procedure will show you how to run a basic AMQ Streams cluster consisting of single Zookeeper and single Apache Kafka node both running on the same host.
-It is using the default configuration files for both Zookeeper and Kafka.
+This procedure will show you how to run a basic AMQ Streams cluster consisting of single {Zookeeper} and single Apache Kafka node both running on the same host.
+It is using the default configuration files for both {Zookeeper} and Kafka.
 
 WARNING: A single node AMQ Streams cluster does not provide reliability and high availability and is suitable only for development purposes.
 
@@ -17,7 +17,7 @@ WARNING: A single node AMQ Streams cluster does not provide reliability and high
 
 .Running the cluster
 
-. Edit the Zookeeper configuration file `/opt/kafka/config/zookeeper.properties`.
+. Edit the {Zookeeper} configuration file `/opt/kafka/config/zookeeper.properties`.
 Set the `dataDir` option to `/var/lib/zookeeper/`.
 +
 [source,properties,subs=+quotes]
@@ -25,7 +25,7 @@ Set the `dataDir` option to `/var/lib/zookeeper/`.
 dataDir=/var/lib/zookeeper/
 ----
 
-. Start Zookeeper.
+. Start {Zookeeper}.
 +
 [source,shell,subs=+quotes]
 ----
@@ -33,7 +33,7 @@ su - kafka
 /opt/kafka/bin/zookeeper-server-start.sh -daemon /opt/kafka/config/zookeeper.properties
 ----
 
-. Make sure that Apache Zookeeper is running.
+. Make sure that Apache {Zookeeper} is running.
 +
 [source,shell,subs=+quotes]
 ----

--- a/books/proc-stopping-amq-streams.adoc
+++ b/books/proc-stopping-amq-streams.adoc
@@ -6,13 +6,13 @@
 
 = Stopping the AMQ Streams services
 
-You can stop the Kafka and {Zookeeper} services by running a script. 
-All connections to the Kafka and {Zookeeper} services will be terminated.
+You can stop the Kafka and ZooKeeper services by running a script. 
+All connections to the Kafka and ZooKeeper services will be terminated.
 
 .Prerequisites
 
 * AMQ Streams is installed on the host
-* {Zookeeper} and Kafka are up and running
+* ZooKeeper and Kafka are up and running
 
 .Procedure
 
@@ -31,7 +31,7 @@ su - kafka
 jcmd | grep kafka
 ----
 
-. Stop {Zookeeper}.
+. Stop ZooKeeper.
 +
 [source,shell,subs=+quotes]
 ----

--- a/books/proc-stopping-amq-streams.adoc
+++ b/books/proc-stopping-amq-streams.adoc
@@ -6,13 +6,13 @@
 
 = Stopping the AMQ Streams services
 
-You can stop the Kafka and Zookeeper services by running a script. 
-All connections to the Kafka and Zookeeper services will be terminated.
+You can stop the Kafka and {Zookeeper} services by running a script. 
+All connections to the Kafka and {Zookeeper} services will be terminated.
 
 .Prerequisites
 
 * AMQ Streams is installed on the host
-* Zookeeper and Kafka are up and running
+* {Zookeeper} and Kafka are up and running
 
 .Procedure
 
@@ -31,7 +31,7 @@ su - kafka
 jcmd | grep kafka
 ----
 
-. Stop Zookeeper.
+. Stop {Zookeeper}.
 +
 [source,shell,subs=+quotes]
 ----

--- a/books/proc-updating-kafka-brokers-to-new-inter-broker-protocol-version.adoc
+++ b/books/proc-updating-kafka-brokers-to-new-inter-broker-protocol-version.adoc
@@ -14,7 +14,7 @@ WARNING: Downgrading {ProductName} is not possible after completing this procedu
 
 .Prerequisites
 
-* xref:proc-upgrading-zookeeper-binaries-{context}[You have updated the {Zookeeper} binaries.]
+* xref:proc-upgrading-zookeeper-binaries-{context}[You have updated the ZooKeeper binaries.]
 * xref:proc-upgrading-kafka-brokers-to-amq-streams-{context}[You have upgraded all Kafka brokers to {ProductName} {ProductVersion}]
 * You are logged in to Red Hat Enterprise Linux as the `kafka` user.
 

--- a/books/proc-updating-kafka-brokers-to-new-inter-broker-protocol-version.adoc
+++ b/books/proc-updating-kafka-brokers-to-new-inter-broker-protocol-version.adoc
@@ -14,7 +14,7 @@ WARNING: Downgrading {ProductName} is not possible after completing this procedu
 
 .Prerequisites
 
-* xref:proc-upgrading-zookeeper-binaries-{context}[You have updated the Zookeeper binaries.]
+* xref:proc-upgrading-zookeeper-binaries-{context}[You have updated the {Zookeeper} binaries.]
 * xref:proc-upgrading-kafka-brokers-to-amq-streams-{context}[You have upgraded all Kafka brokers to {ProductName} {ProductVersion}]
 * You are logged in to Red Hat Enterprise Linux as the `kafka` user.
 

--- a/books/proc-updating-kafka-brokers-to-new-message-format-version.adoc
+++ b/books/proc-updating-kafka-brokers-to-new-message-format-version.adoc
@@ -14,7 +14,7 @@ NOTE: Update and restart the Kafka brokers one-by-one. Before you restart a modi
 
 .Prerequisites
 
-* xref:proc-upgrading-zookeeper-binaries-{context}[You have updated the Zookeeper binaries.]
+* xref:proc-upgrading-zookeeper-binaries-{context}[You have updated the {Zookeeper} binaries.]
 * xref:proc-upgrading-kafka-brokers-to-amq-streams-{context}[You have upgraded all Kafka brokers to {ProductName} {ProductVersion}.]
 * xref:proc-updating-kafka-brokers-to-new-inter-broker-protocol-version-{context}[You have configured Kafka brokers to use the new inter-broker protocol version.]
 * xref:proc-upgrading-clients-to-new-kafka-version-{context}[You have upgraded supported client applications that consume messages from topics for which the `message.format.version` property is _not_ explicitly configured at the topic level.]

--- a/books/proc-updating-kafka-brokers-to-new-message-format-version.adoc
+++ b/books/proc-updating-kafka-brokers-to-new-message-format-version.adoc
@@ -14,7 +14,7 @@ NOTE: Update and restart the Kafka brokers one-by-one. Before you restart a modi
 
 .Prerequisites
 
-* xref:proc-upgrading-zookeeper-binaries-{context}[You have updated the {Zookeeper} binaries.]
+* xref:proc-upgrading-zookeeper-binaries-{context}[You have updated the ZooKeeper binaries.]
 * xref:proc-upgrading-kafka-brokers-to-amq-streams-{context}[You have upgraded all Kafka brokers to {ProductName} {ProductVersion}.]
 * xref:proc-updating-kafka-brokers-to-new-inter-broker-protocol-version-{context}[You have configured Kafka brokers to use the new inter-broker protocol version.]
 * xref:proc-upgrading-clients-to-new-kafka-version-{context}[You have upgraded supported client applications that consume messages from topics for which the `message.format.version` property is _not_ explicitly configured at the topic level.]

--- a/books/proc-upgrading-clients-to-new-kafka-version.adoc
+++ b/books/proc-upgrading-clients-to-new-kafka-version.adoc
@@ -14,7 +14,7 @@ Client applications might include producers, consumers, Kafka Connect, and Mirro
 
 .Prerequisites
 
-* xref:proc-upgrading-zookeeper-binaries-{context}[You have updated the Zookeeper binaries.]
+* xref:proc-upgrading-zookeeper-binaries-{context}[You have updated the {Zookeeper} binaries.]
 * xref:proc-upgrading-kafka-brokers-to-amq-streams-{context}[You have upgraded all Kafka brokers to {ProductName} {ProductVersion}.]
 * xref:proc-updating-kafka-brokers-to-new-inter-broker-protocol-version-{context}[You have configured Kafka brokers to use the new inter-broker protocol version.]
 * You are logged in to {ProductPlatformName} as the `kafka` user.
@@ -27,7 +27,7 @@ For each topic:
 +
 [source,shell,subs="+quotes,attributes"]
 ----
-bin/kafka-configs.sh --zookeeper _<ZookeeperAddress>_ --entity-type topics --entity-name _<TopicName>_ --alter --add-config message.format.version={LogMsgVersLower}
+bin/kafka-configs.sh --zookeeper _<{Zookeeper}Address>_ --entity-type topics --entity-name _<TopicName>_ --alter --add-config message.format.version={LogMsgVersLower}
 ----
 
 . Upgrade all the consuming and producing applications for the topic.
@@ -38,7 +38,7 @@ bin/kafka-configs.sh --zookeeper _<ZookeeperAddress>_ --entity-type topics --ent
 +
 [source,shell,subs="+quotes,attributes"]
 ----
-bin/kafka-configs.sh --zookeeper _<ZookeeperAddress>_ --entity-type topics --entity-name _<TopicName>_ --alter --add-config message.format.version={LogMsgVersHigher}
+bin/kafka-configs.sh --zookeeper _<{Zookeeper}Address>_ --entity-type topics --entity-name _<TopicName>_ --alter --add-config message.format.version={LogMsgVersHigher}
 ----
 
 .Additional resources

--- a/books/proc-upgrading-clients-to-new-kafka-version.adoc
+++ b/books/proc-upgrading-clients-to-new-kafka-version.adoc
@@ -14,7 +14,7 @@ Client applications might include producers, consumers, Kafka Connect, and Mirro
 
 .Prerequisites
 
-* xref:proc-upgrading-zookeeper-binaries-{context}[You have updated the {Zookeeper} binaries.]
+* xref:proc-upgrading-zookeeper-binaries-{context}[You have updated the ZooKeeper binaries.]
 * xref:proc-upgrading-kafka-brokers-to-amq-streams-{context}[You have upgraded all Kafka brokers to {ProductName} {ProductVersion}.]
 * xref:proc-updating-kafka-brokers-to-new-inter-broker-protocol-version-{context}[You have configured Kafka brokers to use the new inter-broker protocol version.]
 * You are logged in to {ProductPlatformName} as the `kafka` user.
@@ -27,7 +27,7 @@ For each topic:
 +
 [source,shell,subs="+quotes,attributes"]
 ----
-bin/kafka-configs.sh --zookeeper _<{Zookeeper}Address>_ --entity-type topics --entity-name _<TopicName>_ --alter --add-config message.format.version={LogMsgVersLower}
+bin/kafka-configs.sh --zookeeper _<ZooKeeperAddress>_ --entity-type topics --entity-name _<TopicName>_ --alter --add-config message.format.version={LogMsgVersLower}
 ----
 
 . Upgrade all the consuming and producing applications for the topic.
@@ -38,7 +38,7 @@ bin/kafka-configs.sh --zookeeper _<{Zookeeper}Address>_ --entity-type topics --e
 +
 [source,shell,subs="+quotes,attributes"]
 ----
-bin/kafka-configs.sh --zookeeper _<{Zookeeper}Address>_ --entity-type topics --entity-name _<TopicName>_ --alter --add-config message.format.version={LogMsgVersHigher}
+bin/kafka-configs.sh --zookeeper _<ZooKeeperAddress>_ --entity-type topics --entity-name _<TopicName>_ --alter --add-config message.format.version={LogMsgVersHigher}
 ----
 
 .Additional resources

--- a/books/proc-upgrading-zookeeper-binaries.adoc
+++ b/books/proc-upgrading-zookeeper-binaries.adoc
@@ -4,9 +4,9 @@
 
 [id='proc-upgrading-zookeeper-binaries-{context}']
 
-= Upgrading Zookeeper
+= Upgrading {Zookeeper}
 
-This procedure describes how to upgrade Zookeeper on a host machine.
+This procedure describes how to upgrade {Zookeeper} on a host machine.
 
 .Prerequisites
 
@@ -51,7 +51,7 @@ cp -r /tmp/kafka/kafka_y.y-x.x.x/docs /opt/kafka/
 rm -rf /tmp/kafka
 ----
 
-. Restart Zookeeper:
+. Restart {Zookeeper}:
 +
 [source,shell,subs=+quotes]
 ----

--- a/books/proc-upgrading-zookeeper-binaries.adoc
+++ b/books/proc-upgrading-zookeeper-binaries.adoc
@@ -4,9 +4,9 @@
 
 [id='proc-upgrading-zookeeper-binaries-{context}']
 
-= Upgrading {Zookeeper}
+= Upgrading ZooKeeper
 
-This procedure describes how to upgrade {Zookeeper} on a host machine.
+This procedure describes how to upgrade ZooKeeper on a host machine.
 
 .Prerequisites
 
@@ -51,7 +51,7 @@ cp -r /tmp/kafka/kafka_y.y-x.x.x/docs /opt/kafka/
 rm -rf /tmp/kafka
 ----
 
-. Restart {Zookeeper}:
+. Restart ZooKeeper:
 +
 [source,shell,subs=+quotes]
 ----

--- a/books/proc-using-amq-streams.adoc
+++ b/books/proc-using-amq-streams.adoc
@@ -9,7 +9,7 @@
 .Prerequisites
 
 * AMQ Streams is installed on the host
-* Zookeeper and Kafka are up and running
+* {Zookeeper} and Kafka are up and running
 
 .Procedure
 

--- a/books/proc-using-amq-streams.adoc
+++ b/books/proc-using-amq-streams.adoc
@@ -9,7 +9,7 @@
 .Prerequisites
 
 * AMQ Streams is installed on the host
-* {Zookeeper} and Kafka are up and running
+* ZooKeeper and Kafka are up and running
 
 .Procedure
 

--- a/books/proc-zookeeper-enable-client-to-server-auth-digest-md5.adoc
+++ b/books/proc-zookeeper-enable-client-to-server-auth-digest-md5.adoc
@@ -6,18 +6,18 @@
 
 = Enabling Client-to-server authentication using DIGEST-MD5
 
-This procedure describes how to enable authentication using the SASL DIGEST-MD5 mechanism between Zookeeper clients and Zookeeper.
+This procedure describes how to enable authentication using the SASL DIGEST-MD5 mechanism between {Zookeeper} clients and {Zookeeper}.
 
 .Prerequisites
 
 * AMQ Streams is installed on the host
-* Zookeeper cluster is xref:proc-running-multinode-zookeeper-cluster-{context}[configured and running].
+* {Zookeeper} cluster is xref:proc-running-multinode-zookeeper-cluster-{context}[configured and running].
 
 .Enabling SASL DIGEST-MD5 authentication
 
-. On all Zookeeper nodes, create or edit the `/opt/kafka/config/zookeeper-jaas.conf` JAAS configuration file and add the following context:
+. On all {Zookeeper} nodes, create or edit the `/opt/kafka/config/zookeeper-jaas.conf` JAAS configuration file and add the following context:
 +
-[source,subs=+quotes]
+[source,subs="+quotes,attributes"]
 ----
 Server {
     org.apache.zookeeper.server.auth.DigestLoginModule required
@@ -42,7 +42,7 @@ Server {
 };
 ----
 
-. On all Zookeeper nodes, edit the `/opt/kafka/config/zookeeper.properties` Zookeeper configuration file and set the following options:
+. On all {Zookeeper} nodes, edit the `/opt/kafka/config/zookeeper.properties` {Zookeeper} configuration file and set the following options:
 +
 [source,ini,subs=+quotes]
 ----
@@ -52,8 +52,8 @@ authProvider._<IdOfBroker2>_=org.apache.zookeeper.server.auth.SASLAuthentication
 authProvider._<IdOfBroker3>_=org.apache.zookeeper.server.auth.SASLAuthenticationProvider
 ----
 +
-The `authProvider._<ID>_` property has to be added for every node which is part of the Zookeeper cluster.
-An example three-node Zookeeper cluster configuration must look like the following:
+The `authProvider._<ID>_` property has to be added for every node which is part of the {Zookeeper} cluster.
+An example three-node {Zookeeper} cluster configuration must look like the following:
 +
 [source,ini,subs=+quotes]
 ----
@@ -63,8 +63,8 @@ authProvider.2=org.apache.zookeeper.server.auth.SASLAuthenticationProvider
 authProvider.3=org.apache.zookeeper.server.auth.SASLAuthenticationProvider
 ----
 
-. Restart all Zookeeper nodes one by one.
-To pass the JAAS configuration to Zookeeper, use the `KAFKA_OPTS` environment variable.
+. Restart all {Zookeeper} nodes one by one.
+To pass the JAAS configuration to {Zookeeper}, use the `KAFKA_OPTS` environment variable.
 +
 [source]
 ----
@@ -76,4 +76,4 @@ export KAFKA_OPTS="-Djava.security.auth.login.config=/opt/kafka/config/zookeeper
 
 * For more information about installing AMQ Streams, see xref:proc-installing-amq-streams-{context}[].
 * For more information about configuring AMQ Streams, see xref:proc-configuring-amq-streams-{context}[].
-* For more information about running a Zookeeper cluster, see xref:proc-running-multinode-zookeeper-cluster-{context}[].
+* For more information about running a {Zookeeper} cluster, see xref:proc-running-multinode-zookeeper-cluster-{context}[].

--- a/books/proc-zookeeper-enable-client-to-server-auth-digest-md5.adoc
+++ b/books/proc-zookeeper-enable-client-to-server-auth-digest-md5.adoc
@@ -6,16 +6,16 @@
 
 = Enabling Client-to-server authentication using DIGEST-MD5
 
-This procedure describes how to enable authentication using the SASL DIGEST-MD5 mechanism between {Zookeeper} clients and {Zookeeper}.
+This procedure describes how to enable authentication using the SASL DIGEST-MD5 mechanism between ZooKeeper clients and ZooKeeper.
 
 .Prerequisites
 
 * AMQ Streams is installed on the host
-* {Zookeeper} cluster is xref:proc-running-multinode-zookeeper-cluster-{context}[configured and running].
+* ZooKeeper cluster is xref:proc-running-multinode-zookeeper-cluster-{context}[configured and running].
 
 .Enabling SASL DIGEST-MD5 authentication
 
-. On all {Zookeeper} nodes, create or edit the `/opt/kafka/config/zookeeper-jaas.conf` JAAS configuration file and add the following context:
+. On all ZooKeeper nodes, create or edit the `/opt/kafka/config/zookeeper-jaas.conf` JAAS configuration file and add the following context:
 +
 [source,subs="+quotes,attributes"]
 ----
@@ -42,7 +42,7 @@ Server {
 };
 ----
 
-. On all {Zookeeper} nodes, edit the `/opt/kafka/config/zookeeper.properties` {Zookeeper} configuration file and set the following options:
+. On all ZooKeeper nodes, edit the `/opt/kafka/config/zookeeper.properties` ZooKeeper configuration file and set the following options:
 +
 [source,ini,subs=+quotes]
 ----
@@ -52,8 +52,8 @@ authProvider._<IdOfBroker2>_=org.apache.zookeeper.server.auth.SASLAuthentication
 authProvider._<IdOfBroker3>_=org.apache.zookeeper.server.auth.SASLAuthenticationProvider
 ----
 +
-The `authProvider._<ID>_` property has to be added for every node which is part of the {Zookeeper} cluster.
-An example three-node {Zookeeper} cluster configuration must look like the following:
+The `authProvider._<ID>_` property has to be added for every node which is part of the ZooKeeper cluster.
+An example three-node ZooKeeper cluster configuration must look like the following:
 +
 [source,ini,subs=+quotes]
 ----
@@ -63,8 +63,8 @@ authProvider.2=org.apache.zookeeper.server.auth.SASLAuthenticationProvider
 authProvider.3=org.apache.zookeeper.server.auth.SASLAuthenticationProvider
 ----
 
-. Restart all {Zookeeper} nodes one by one.
-To pass the JAAS configuration to {Zookeeper}, use the `KAFKA_OPTS` environment variable.
+. Restart all ZooKeeper nodes one by one.
+To pass the JAAS configuration to ZooKeeper, use the `KAFKA_OPTS` environment variable.
 +
 [source]
 ----
@@ -76,4 +76,4 @@ export KAFKA_OPTS="-Djava.security.auth.login.config=/opt/kafka/config/zookeeper
 
 * For more information about installing AMQ Streams, see xref:proc-installing-amq-streams-{context}[].
 * For more information about configuring AMQ Streams, see xref:proc-configuring-amq-streams-{context}[].
-* For more information about running a {Zookeeper} cluster, see xref:proc-running-multinode-zookeeper-cluster-{context}[].
+* For more information about running a ZooKeeper cluster, see xref:proc-running-multinode-zookeeper-cluster-{context}[].

--- a/books/proc-zookeeper-enable-server-to-server-auth-digest-md5.adoc
+++ b/books/proc-zookeeper-enable-server-to-server-auth-digest-md5.adoc
@@ -6,22 +6,22 @@
 
 = Enabling Server-to-server authentication using DIGEST-MD5
 
-This procedure describes how to enable authentication using the SASL DIGEST-MD5 mechanism between the nodes of the Zookeeper cluster.
+This procedure describes how to enable authentication using the SASL DIGEST-MD5 mechanism between the nodes of the {Zookeeper} cluster.
 
 .Prerequisites
 
 * AMQ Streams is installed on the host
-* Zookeeper cluster is xref:proc-running-multinode-zookeeper-cluster-{context}[configured] with multiple nodes.
+* {Zookeeper} cluster is xref:proc-running-multinode-zookeeper-cluster-{context}[configured] with multiple nodes.
 
 .Enabling SASL DIGEST-MD5 authentication
 
-. On all Zookeeper nodes, create or edit the `/opt/kafka/config/zookeeper-jaas.conf` JAAS configuration file and add the following contexts:
+. On all {Zookeeper} nodes, create or edit the `/opt/kafka/config/zookeeper-jaas.conf` JAAS configuration file and add the following contexts:
 +
-[source,subs=+quotes]
+[source,subs="+quotes,attributes"]
 ----
 QuorumServer {
        org.apache.zookeeper.server.auth.DigestLoginModule required
-       user__<Username>_="_<Password>_";
+       user{underscore}__<Username>__="_<Password>_";
 };
 
 QuorumLearner {
@@ -48,7 +48,7 @@ QuorumLearner {
 };
 ----
 
-. On all Zookeeper nodes, edit the `/opt/kafka/config/zookeeper.properties` Zookeeper configuration file and set the following options:
+. On all {Zookeeper} nodes, edit the `/opt/kafka/config/zookeeper.properties` {Zookeeper} configuration file and set the following options:
 +
 [source,ini,subs=+quotes]
 ----
@@ -60,8 +60,8 @@ quorum.auth.server.loginContext=QuorumServer
 quorum.cnxn.threads.size=20
 ----
 
-. Restart all Zookeeper nodes one by one.
-To pass the JAAS configuration to Zookeeper, use the `KAFKA_OPTS` environment variable.
+. Restart all {Zookeeper} nodes one by one.
+To pass the JAAS configuration to {Zookeeper}, use the `KAFKA_OPTS` environment variable.
 +
 [source]
 ----
@@ -73,4 +73,4 @@ export KAFKA_OPTS="-Djava.security.auth.login.config=/opt/kafka/config/zookeeper
 
 * For more information about installing AMQ Streams, see xref:proc-installing-amq-streams-{context}[].
 * For more information about configuring AMQ Streams, see xref:proc-configuring-amq-streams-{context}[].
-* For more information about running a Zookeeper cluster, see xref:proc-running-multinode-zookeeper-cluster-{context}[].
+* For more information about running a {Zookeeper} cluster, see xref:proc-running-multinode-zookeeper-cluster-{context}[].

--- a/books/proc-zookeeper-enable-server-to-server-auth-digest-md5.adoc
+++ b/books/proc-zookeeper-enable-server-to-server-auth-digest-md5.adoc
@@ -6,16 +6,16 @@
 
 = Enabling Server-to-server authentication using DIGEST-MD5
 
-This procedure describes how to enable authentication using the SASL DIGEST-MD5 mechanism between the nodes of the {Zookeeper} cluster.
+This procedure describes how to enable authentication using the SASL DIGEST-MD5 mechanism between the nodes of the ZooKeeper cluster.
 
 .Prerequisites
 
 * AMQ Streams is installed on the host
-* {Zookeeper} cluster is xref:proc-running-multinode-zookeeper-cluster-{context}[configured] with multiple nodes.
+* ZooKeeper cluster is xref:proc-running-multinode-zookeeper-cluster-{context}[configured] with multiple nodes.
 
 .Enabling SASL DIGEST-MD5 authentication
 
-. On all {Zookeeper} nodes, create or edit the `/opt/kafka/config/zookeeper-jaas.conf` JAAS configuration file and add the following contexts:
+. On all ZooKeeper nodes, create or edit the `/opt/kafka/config/zookeeper-jaas.conf` JAAS configuration file and add the following contexts:
 +
 [source,subs="+quotes,attributes"]
 ----
@@ -48,7 +48,7 @@ QuorumLearner {
 };
 ----
 
-. On all {Zookeeper} nodes, edit the `/opt/kafka/config/zookeeper.properties` {Zookeeper} configuration file and set the following options:
+. On all ZooKeeper nodes, edit the `/opt/kafka/config/zookeeper.properties` ZooKeeper configuration file and set the following options:
 +
 [source,ini,subs=+quotes]
 ----
@@ -60,8 +60,8 @@ quorum.auth.server.loginContext=QuorumServer
 quorum.cnxn.threads.size=20
 ----
 
-. Restart all {Zookeeper} nodes one by one.
-To pass the JAAS configuration to {Zookeeper}, use the `KAFKA_OPTS` environment variable.
+. Restart all ZooKeeper nodes one by one.
+To pass the JAAS configuration to ZooKeeper, use the `KAFKA_OPTS` environment variable.
 +
 [source]
 ----
@@ -73,4 +73,4 @@ export KAFKA_OPTS="-Djava.security.auth.login.config=/opt/kafka/config/zookeeper
 
 * For more information about installing AMQ Streams, see xref:proc-installing-amq-streams-{context}[].
 * For more information about configuring AMQ Streams, see xref:proc-configuring-amq-streams-{context}[].
-* For more information about running a {Zookeeper} cluster, see xref:proc-running-multinode-zookeeper-cluster-{context}[].
+* For more information about running a ZooKeeper cluster, see xref:proc-running-multinode-zookeeper-cluster-{context}[].

--- a/books/ref-broker-config.adoc
+++ b/books/ref-broker-config.adoc
@@ -13,8 +13,8 @@
 *Importance:* high +
 *Dynamic update:* read-only +
 +
-Specifies the {Zookeeper} connection string in the form `hostname:port` where host and port are the host and port of a {Zookeeper} server. To allow connecting through other {Zookeeper} nodes when that {Zookeeper} machine is down you can also specify multiple hosts in the form `hostname1:port1,hostname2:port2,hostname3:port3`.
-The server can also have a {Zookeeper} chroot path as part of its {Zookeeper} connection string which puts its data under some path in the global {Zookeeper} namespace. For example to give a chroot path of `/chroot/path` you would give the connection string as `hostname1:port1,hostname2:port2,hostname3:port3/chroot/path`.
+Specifies the ZooKeeper connection string in the form `hostname:port` where host and port are the host and port of a ZooKeeper server. To allow connecting through other ZooKeeper nodes when that ZooKeeper machine is down you can also specify multiple hosts in the form `hostname1:port1,hostname2:port2,hostname3:port3`.
+The server can also have a ZooKeeper chroot path as part of its ZooKeeper connection string which puts its data under some path in the global ZooKeeper namespace. For example to give a chroot path of `/chroot/path` you would give the connection string as `hostname1:port1,hostname2:port2,hostname3:port3/chroot/path`.
 
 `advertised.host.name`::
 *Type:* string +
@@ -23,7 +23,7 @@ The server can also have a {Zookeeper} chroot path as part of its {Zookeeper} co
 *Dynamic update:* read-only +
 +
 DEPRECATED: only used when `advertised.listeners` or `listeners` are not set. Use `advertised.listeners` instead.
-Hostname to publish to {Zookeeper} for clients to use. In IaaS environments, this may need to be different from the interface to which the broker binds. If this is not set, it will use the value for `host.name` if configured. Otherwise it will use the value returned from java.net.InetAddress.getCanonicalHostName().
+Hostname to publish to ZooKeeper for clients to use. In IaaS environments, this may need to be different from the interface to which the broker binds. If this is not set, it will use the value for `host.name` if configured. Otherwise it will use the value returned from java.net.InetAddress.getCanonicalHostName().
 
 `advertised.listeners`::
 *Type:* string +
@@ -31,7 +31,7 @@ Hostname to publish to {Zookeeper} for clients to use. In IaaS environments, thi
 *Importance:* high +
 *Dynamic update:* per-broker +
 +
-Listeners to publish to {Zookeeper} for clients to use, if different than the `listeners` config property. In IaaS environments, this may need to be different from the interface to which the broker binds. If this is not set, the value for `listeners` will be used. Unlike `listeners` it is not valid to advertise the 0.0.0.0 meta-address.
+Listeners to publish to ZooKeeper for clients to use, if different than the `listeners` config property. In IaaS environments, this may need to be different from the interface to which the broker binds. If this is not set, the value for `listeners` will be used. Unlike `listeners` it is not valid to advertise the 0.0.0.0 meta-address.
 
 `advertised.port`::
 *Type:* int +
@@ -40,7 +40,7 @@ Listeners to publish to {Zookeeper} for clients to use, if different than the `l
 *Dynamic update:* read-only +
 +
 DEPRECATED: only used when `advertised.listeners` or `listeners` are not set. Use `advertised.listeners` instead.
-The port to publish to {Zookeeper} for clients to use. In IaaS environments, this may need to be different from the port to which the broker binds. If this is not set, it will publish the same port that the broker binds to.
+The port to publish to ZooKeeper for clients to use. In IaaS environments, this may need to be different from the port to which the broker binds. If this is not set, it will publish the same port that the broker binds to.
 
 `auto.create.topics.enable`::
 *Type:* boolean +
@@ -73,7 +73,7 @@ The number of threads to use for various background processing tasks.
 *Importance:* high +
 *Dynamic update:* read-only +
 +
-The broker id for this server. If unset, a unique broker id will be generated.To avoid conflicts between {Zookeeper} generated broker id's and user configured broker id's, generated broker ids start from reserved.broker.max.id + 1.
+The broker id for this server. If unset, a unique broker id will be generated.To avoid conflicts between ZooKeeper generated broker id's and user configured broker id's, generated broker ids start from reserved.broker.max.id + 1.
 
 `compression.type`::
 *Type:* string +
@@ -94,8 +94,8 @@ listeners = INTERNAL://192.1.1.8:9092, EXTERNAL://10.1.1.5:9093, CONTROLLER://19
 listener.security.protocol.map = INTERNAL:PLAINTEXT, EXTERNAL:SSL, CONTROLLER:SSL
 control.plane.listener.name = CONTROLLER
 On startup, the broker will start listening on "192.1.1.8:9094" with security protocol "SSL".
-On controller side, when it discovers a broker's published endpoints through {Zookeeper}, it will use the control.plane.listener.name to find the endpoint, which it will use to establish connection to the broker.
-For example, if the broker's published endpoints on {Zookeeper} are :
+On controller side, when it discovers a broker's published endpoints through ZooKeeper, it will use the control.plane.listener.name to find the endpoint, which it will use to establish connection to the broker.
+For example, if the broker's published endpoints on ZooKeeper are :
 "endpoints" : ["INTERNAL://broker1.example.com:9092","EXTERNAL://broker1.example.com:9093","CONTROLLER://broker1.example.com:9094"]
  and the controller's config is :
 listener.security.protocol.map = INTERNAL:PLAINTEXT, EXTERNAL:SSL, CONTROLLER:SSL
@@ -473,7 +473,7 @@ The number of queued requests allowed for data-plane, before blocking the networ
 *Importance:* high +
 *Dynamic update:* read-only +
 +
-DEPRECATED: Used only when dynamic default quotas are not configured for <user, <client-id> or <user, client-id> in {Zookeeper}. Any consumer distinguished by clientId/consumer group will get throttled if it fetches more bytes than this value per-second.
+DEPRECATED: Used only when dynamic default quotas are not configured for <user, <client-id> or <user, client-id> in ZooKeeper. Any consumer distinguished by clientId/consumer group will get throttled if it fetches more bytes than this value per-second.
 
 `quota.producer.default`::
 *Type:* long +
@@ -482,7 +482,7 @@ DEPRECATED: Used only when dynamic default quotas are not configured for <user, 
 *Importance:* high +
 *Dynamic update:* read-only +
 +
-DEPRECATED: Used only when dynamic default quotas are not configured for <user>, <client-id> or <user, client-id> in {Zookeeper}. Any producer distinguished by clientId will get throttled if it produces more bytes than this value per-second.
+DEPRECATED: Used only when dynamic default quotas are not configured for <user>, <client-id> or <user, client-id> in ZooKeeper. Any producer distinguished by clientId will get throttled if it produces more bytes than this value per-second.
 
 `replica.fetch.min.bytes`::
 *Type:* int +
@@ -642,7 +642,7 @@ Indicates whether to enable replicas not in the ISR set to be elected as leader 
 *Importance:* high +
 *Dynamic update:* read-only +
 +
-The max time that the client waits to establish a connection to {Zookeeper}. If not set, the value in zookeeper.session.timeout.ms is used.
+The max time that the client waits to establish a connection to ZooKeeper. If not set, the value in zookeeper.session.timeout.ms is used.
 
 `zookeeper.max.in.flight.requests`::
 *Type:* int +
@@ -651,7 +651,7 @@ The max time that the client waits to establish a connection to {Zookeeper}. If 
 *Importance:* high +
 *Dynamic update:* read-only +
 +
-The maximum number of unacknowledged requests the client will send to {Zookeeper} before blocking.
+The maximum number of unacknowledged requests the client will send to ZooKeeper before blocking.
 
 `zookeeper.session.timeout.ms`::
 *Type:* int +
@@ -659,7 +659,7 @@ The maximum number of unacknowledged requests the client will send to {Zookeeper
 *Importance:* high +
 *Dynamic update:* read-only +
 +
-{Zookeeper} session timeout.
+ZooKeeper session timeout.
 
 `zookeeper.set.acl`::
 *Type:* boolean +
@@ -1417,7 +1417,7 @@ The authorizer class that should be used for authorization.
 *Importance:* low +
 *Dynamic update:* read-only +
 +
-The fully qualified name of a class that implements the ClientQuotaCallback interface, which is used to determine quota limits applied to client requests. By default, <user, client-id>, <user> or <client-id> quotas stored in {Zookeeper} are applied. For any given request, the most specific quota that matches the user principal of the session and the client-id of the request is applied.
+The fully qualified name of a class that implements the ClientQuotaCallback interface, which is used to determine quota limits applied to client requests. By default, <user, client-id>, <user> or <client-id> quotas stored in ZooKeeper are applied. For any given request, the most specific quota that matches the user principal of the session and the client-id of the request is applied.
 
 `connection.failed.authentication.delay.ms`::
 *Type:* int +

--- a/books/ref-broker-config.adoc
+++ b/books/ref-broker-config.adoc
@@ -13,8 +13,8 @@
 *Importance:* high +
 *Dynamic update:* read-only +
 +
-Specifies the ZooKeeper connection string in the form `hostname:port` where host and port are the host and port of a ZooKeeper server. To allow connecting through other ZooKeeper nodes when that ZooKeeper machine is down you can also specify multiple hosts in the form `hostname1:port1,hostname2:port2,hostname3:port3`.
-The server can also have a ZooKeeper chroot path as part of its ZooKeeper connection string which puts its data under some path in the global ZooKeeper namespace. For example to give a chroot path of `/chroot/path` you would give the connection string as `hostname1:port1,hostname2:port2,hostname3:port3/chroot/path`.
+Specifies the {Zookeeper} connection string in the form `hostname:port` where host and port are the host and port of a {Zookeeper} server. To allow connecting through other {Zookeeper} nodes when that {Zookeeper} machine is down you can also specify multiple hosts in the form `hostname1:port1,hostname2:port2,hostname3:port3`.
+The server can also have a {Zookeeper} chroot path as part of its {Zookeeper} connection string which puts its data under some path in the global {Zookeeper} namespace. For example to give a chroot path of `/chroot/path` you would give the connection string as `hostname1:port1,hostname2:port2,hostname3:port3/chroot/path`.
 
 `advertised.host.name`::
 *Type:* string +
@@ -22,8 +22,8 @@ The server can also have a ZooKeeper chroot path as part of its ZooKeeper connec
 *Importance:* high +
 *Dynamic update:* read-only +
 +
-DEPRECATED: only used when `advertised.listeners` or `listeners` are not set. Use `advertised.listeners` instead. 
-Hostname to publish to ZooKeeper for clients to use. In IaaS environments, this may need to be different from the interface to which the broker binds. If this is not set, it will use the value for `host.name` if configured. Otherwise it will use the value returned from java.net.InetAddress.getCanonicalHostName().
+DEPRECATED: only used when `advertised.listeners` or `listeners` are not set. Use `advertised.listeners` instead.
+Hostname to publish to {Zookeeper} for clients to use. In IaaS environments, this may need to be different from the interface to which the broker binds. If this is not set, it will use the value for `host.name` if configured. Otherwise it will use the value returned from java.net.InetAddress.getCanonicalHostName().
 
 `advertised.listeners`::
 *Type:* string +
@@ -31,7 +31,7 @@ Hostname to publish to ZooKeeper for clients to use. In IaaS environments, this 
 *Importance:* high +
 *Dynamic update:* per-broker +
 +
-Listeners to publish to ZooKeeper for clients to use, if different than the `listeners` config property. In IaaS environments, this may need to be different from the interface to which the broker binds. If this is not set, the value for `listeners` will be used. Unlike `listeners` it is not valid to advertise the 0.0.0.0 meta-address.
+Listeners to publish to {Zookeeper} for clients to use, if different than the `listeners` config property. In IaaS environments, this may need to be different from the interface to which the broker binds. If this is not set, the value for `listeners` will be used. Unlike `listeners` it is not valid to advertise the 0.0.0.0 meta-address.
 
 `advertised.port`::
 *Type:* int +
@@ -39,8 +39,8 @@ Listeners to publish to ZooKeeper for clients to use, if different than the `lis
 *Importance:* high +
 *Dynamic update:* read-only +
 +
-DEPRECATED: only used when `advertised.listeners` or `listeners` are not set. Use `advertised.listeners` instead. 
-The port to publish to ZooKeeper for clients to use. In IaaS environments, this may need to be different from the port to which the broker binds. If this is not set, it will publish the same port that the broker binds to.
+DEPRECATED: only used when `advertised.listeners` or `listeners` are not set. Use `advertised.listeners` instead.
+The port to publish to {Zookeeper} for clients to use. In IaaS environments, this may need to be different from the port to which the broker binds. If this is not set, it will publish the same port that the broker binds to.
 
 `auto.create.topics.enable`::
 *Type:* boolean +
@@ -73,7 +73,7 @@ The number of threads to use for various background processing tasks.
 *Importance:* high +
 *Dynamic update:* read-only +
 +
-The broker id for this server. If unset, a unique broker id will be generated.To avoid conflicts between zookeeper generated broker id's and user configured broker id's, generated broker ids start from reserved.broker.max.id + 1.
+The broker id for this server. If unset, a unique broker id will be generated.To avoid conflicts between {Zookeeper} generated broker id's and user configured broker id's, generated broker ids start from reserved.broker.max.id + 1.
 
 `compression.type`::
 *Type:* string +
@@ -94,8 +94,8 @@ listeners = INTERNAL://192.1.1.8:9092, EXTERNAL://10.1.1.5:9093, CONTROLLER://19
 listener.security.protocol.map = INTERNAL:PLAINTEXT, EXTERNAL:SSL, CONTROLLER:SSL
 control.plane.listener.name = CONTROLLER
 On startup, the broker will start listening on "192.1.1.8:9094" with security protocol "SSL".
-On controller side, when it discovers a broker's published endpoints through zookeeper, it will use the control.plane.listener.name to find the endpoint, which it will use to establish connection to the broker.
-For example, if the broker's published endpoints on zookeeper are :
+On controller side, when it discovers a broker's published endpoints through {Zookeeper}, it will use the control.plane.listener.name to find the endpoint, which it will use to establish connection to the broker.
+For example, if the broker's published endpoints on {Zookeeper} are :
 "endpoints" : ["INTERNAL://broker1.example.com:9092","EXTERNAL://broker1.example.com:9093","CONTROLLER://broker1.example.com:9094"]
  and the controller's config is :
 listener.security.protocol.map = INTERNAL:PLAINTEXT, EXTERNAL:SSL, CONTROLLER:SSL
@@ -117,7 +117,7 @@ Enables delete topic. Delete topic through the admin tool will have no effect if
 *Importance:* high +
 *Dynamic update:* read-only +
 +
-DEPRECATED: only used when `listeners` is not set. Use `listeners` instead. 
+DEPRECATED: only used when `listeners` is not set. Use `listeners` instead.
 hostname of broker. If this is set, it will only bind to this address. If this is not set, it will bind to all interfaces.
 
 `leader.imbalance.check.interval.seconds`::
@@ -454,7 +454,7 @@ The offsets topic segment bytes should be kept relatively small in order to faci
 *Importance:* high +
 *Dynamic update:* read-only +
 +
-DEPRECATED: only used when `listeners` is not set. Use `listeners` instead. 
+DEPRECATED: only used when `listeners` is not set. Use `listeners` instead.
 the port to listen and accept connections on.
 
 `queued.max.requests`::
@@ -473,7 +473,7 @@ The number of queued requests allowed for data-plane, before blocking the networ
 *Importance:* high +
 *Dynamic update:* read-only +
 +
-DEPRECATED: Used only when dynamic default quotas are not configured for <user, <client-id> or <user, client-id> in Zookeeper. Any consumer distinguished by clientId/consumer group will get throttled if it fetches more bytes than this value per-second.
+DEPRECATED: Used only when dynamic default quotas are not configured for <user, <client-id> or <user, client-id> in {Zookeeper}. Any consumer distinguished by clientId/consumer group will get throttled if it fetches more bytes than this value per-second.
 
 `quota.producer.default`::
 *Type:* long +
@@ -482,7 +482,7 @@ DEPRECATED: Used only when dynamic default quotas are not configured for <user, 
 *Importance:* high +
 *Dynamic update:* read-only +
 +
-DEPRECATED: Used only when dynamic default quotas are not configured for <user>, <client-id> or <user, client-id> in Zookeeper. Any producer distinguished by clientId will get throttled if it produces more bytes than this value per-second.
+DEPRECATED: Used only when dynamic default quotas are not configured for <user>, <client-id> or <user, client-id> in {Zookeeper}. Any producer distinguished by clientId will get throttled if it produces more bytes than this value per-second.
 
 `replica.fetch.min.bytes`::
 *Type:* int +
@@ -642,7 +642,7 @@ Indicates whether to enable replicas not in the ISR set to be elected as leader 
 *Importance:* high +
 *Dynamic update:* read-only +
 +
-The max time that the client waits to establish a connection to zookeeper. If not set, the value in zookeeper.session.timeout.ms is used.
+The max time that the client waits to establish a connection to {Zookeeper}. If not set, the value in zookeeper.session.timeout.ms is used.
 
 `zookeeper.max.in.flight.requests`::
 *Type:* int +
@@ -651,7 +651,7 @@ The max time that the client waits to establish a connection to zookeeper. If no
 *Importance:* high +
 *Dynamic update:* read-only +
 +
-The maximum number of unacknowledged requests the client will send to Zookeeper before blocking.
+The maximum number of unacknowledged requests the client will send to {Zookeeper} before blocking.
 
 `zookeeper.session.timeout.ms`::
 *Type:* int +
@@ -659,7 +659,7 @@ The maximum number of unacknowledged requests the client will send to Zookeeper 
 *Importance:* high +
 *Dynamic update:* read-only +
 +
-Zookeeper session timeout.
+{Zookeeper} session timeout.
 
 `zookeeper.set.acl`::
 *Type:* boolean +
@@ -1275,10 +1275,10 @@ A list of cipher suites. This is a named combination of authentication, encrypti
 *Importance:* medium +
 *Dynamic update:* per-broker +
 +
-Configures kafka broker to request client authentication. The following settings are common:  
- 
-* `ssl.client.auth=required` If set to required client authentication is required. 
-* `ssl.client.auth=requested` This means client authentication is optional. unlike requested , if this option is set client can choose not to provide authentication information about itself 
+Configures kafka broker to request client authentication. The following settings are common:
+
+* `ssl.client.auth=required` If set to required client authentication is required.
+* `ssl.client.auth=requested` This means client authentication is optional. unlike requested , if this option is set client can choose not to provide authentication information about itself
 * `ssl.client.auth=none` This means client authentication is not needed.
 
 `ssl.enabled.protocols`::
@@ -1417,7 +1417,7 @@ The authorizer class that should be used for authorization.
 *Importance:* low +
 *Dynamic update:* read-only +
 +
-The fully qualified name of a class that implements the ClientQuotaCallback interface, which is used to determine quota limits applied to client requests. By default, <user, client-id>, <user> or <client-id> quotas stored in ZooKeeper are applied. For any given request, the most specific quota that matches the user principal of the session and the client-id of the request is applied.
+The fully qualified name of a class that implements the ClientQuotaCallback interface, which is used to determine quota limits applied to client requests. By default, <user, client-id>, <user> or <client-id> quotas stored in {Zookeeper} are applied. For any given request, the most specific quota that matches the user principal of the session and the client-id of the request is applied.
 
 `connection.failed.authentication.delay.ms`::
 *Type:* int +

--- a/books/ref-kafka-versions.adoc
+++ b/books/ref-kafka-versions.adoc
@@ -20,7 +20,7 @@ The following table shows the differences between Kafka versions:
 
 include::snip-kafka-versions.adoc[]
 
-Although Kafka versions may use the same version of Zookeeper, it is recommended that you update your Zookeeper cluster to use the newest Zookeeper binaries before proceeding with the main {ProductName} upgrade.
+Although Kafka versions may use the same version of {Zookeeper}, it is recommended that you update your {Zookeeper} cluster to use the newest {Zookeeper} binaries before proceeding with the main {ProductName} upgrade.
 
 .Message format version
 

--- a/books/ref-kafka-versions.adoc
+++ b/books/ref-kafka-versions.adoc
@@ -20,7 +20,7 @@ The following table shows the differences between Kafka versions:
 
 include::snip-kafka-versions.adoc[]
 
-Although Kafka versions may use the same version of {Zookeeper}, it is recommended that you update your {Zookeeper} cluster to use the newest {Zookeeper} binaries before proceeding with the main {ProductName} upgrade.
+Although Kafka versions may use the same version of ZooKeeper, it is recommended that you update your ZooKeeper cluster to use the newest ZooKeeper binaries before proceeding with the main {ProductName} upgrade.
 
 .Message format version
 

--- a/books/ref-zookeeper-additional-configuration.adoc
+++ b/books/ref-zookeeper-additional-configuration.adoc
@@ -8,10 +8,10 @@
 
 You can set the following options based on your use case:
 
-`maxClientCnxns`:: The maximum number of concurrent client connections to a single member of the ZooKeeper cluster.
-`autopurge.snapRetainCount`:: Number of snapshots of Zookeeper's in-memory database which will be retained.
+`maxClientCnxns`:: The maximum number of concurrent client connections to a single member of the {Zookeeper} cluster.
+`autopurge.snapRetainCount`:: Number of snapshots of {Zookeeper}'s in-memory database which will be retained.
 Default value is `3`.
 `autopurge.purgeInterval`:: The time interval in hours for purging snapshots.
 The default value is `0` and this option is disabled.
 
-All available configuration options can be found in link:http://zookeeper.apache.org/doc/current/zookeeperAdmin.html#sc_maintenance[Zookeeper documentation^].
+All available configuration options can be found in link:http://zookeeper.apache.org/doc/current/zookeeperAdmin.html#sc_maintenance[{Zookeeper} documentation^].

--- a/books/ref-zookeeper-additional-configuration.adoc
+++ b/books/ref-zookeeper-additional-configuration.adoc
@@ -8,10 +8,10 @@
 
 You can set the following options based on your use case:
 
-`maxClientCnxns`:: The maximum number of concurrent client connections to a single member of the {Zookeeper} cluster.
-`autopurge.snapRetainCount`:: Number of snapshots of {Zookeeper}'s in-memory database which will be retained.
+`maxClientCnxns`:: The maximum number of concurrent client connections to a single member of the ZooKeeper cluster.
+`autopurge.snapRetainCount`:: Number of snapshots of ZooKeeper's in-memory database which will be retained.
 Default value is `3`.
 `autopurge.purgeInterval`:: The time interval in hours for purging snapshots.
 The default value is `0` and this option is disabled.
 
-All available configuration options can be found in link:http://zookeeper.apache.org/doc/current/zookeeperAdmin.html#sc_maintenance[{Zookeeper} documentation^].
+All available configuration options can be found in link:http://zookeeper.apache.org/doc/current/zookeeperAdmin.html#sc_maintenance[ZooKeeper documentation^].

--- a/books/snip-kafka-versions.adoc
+++ b/books/snip-kafka-versions.adoc
@@ -1,6 +1,6 @@
 [options="header"]
 |=================
-|Kafka version |Interbroker protocol version |Log message format version| {Zookeeper} version
+|Kafka version |Interbroker protocol version |Log message format version| ZooKeeper version
 |2.2.1 |2.2 |2.2 |3.4.14
 |2.3.0 |2.3 |2.3 |3.4.14
 |=================

--- a/books/snip-kafka-versions.adoc
+++ b/books/snip-kafka-versions.adoc
@@ -1,6 +1,6 @@
 [options="header"]
 |=================
-|Kafka version |Interbroker protocol version |Log message format version| Zookeeper version
+|Kafka version |Interbroker protocol version |Log message format version| {Zookeeper} version
 |2.2.1 |2.2 |2.2 |3.4.14
 |2.3.0 |2.3 |2.3 |3.4.14
 |=================

--- a/books/snip-reassign-partitions.adoc
+++ b/books/snip-reassign-partitions.adoc
@@ -4,7 +4,7 @@
 +
 [source,shell,subs="+quotes,attributes"]
 ----
-kafka-reassign-partitions.sh --zookeeper _<{Zookeeper}HostAndPort>_ --reassignment-json-file _<ReassignmentJsonFile>_ --execute
+kafka-reassign-partitions.sh --zookeeper _<ZooKeeperHostAndPort>_ --reassignment-json-file _<ReassignmentJsonFile>_ --execute
 ----
 +
 If you are going to throttle replication you can also pass the `--throttle` option with an inter-broker throttled rate in bytes per second. For example:
@@ -30,7 +30,7 @@ kafka-reassign-partitions.sh --zookeeper zookeeper1:2181 --reassignment-json-fil
 +
 [source,shell,subs="+quotes,attributes"]
 ----
-kafka-reassign-partitions.sh --zookeeper _<{Zookeeper}HostAndPort>_ --reassignment-json-file _<ReassignmentJsonFile>_ --verify
+kafka-reassign-partitions.sh --zookeeper _<ZooKeeperHostAndPort>_ --reassignment-json-file _<ReassignmentJsonFile>_ --verify
 ----
 +
 For example:

--- a/books/snip-reassign-partitions.adoc
+++ b/books/snip-reassign-partitions.adoc
@@ -2,9 +2,9 @@
 
 . Execute the partition reassignment using the `kafka-reassign-partitions.sh` command line tool.
 +
-[source,shell,subs=+quotes]
+[source,shell,subs="+quotes,attributes"]
 ----
-kafka-reassign-partitions.sh --zookeeper _<ZookeeperHostAndPort>_ --reassignment-json-file _<ReassignmentJsonFile>_ --execute
+kafka-reassign-partitions.sh --zookeeper _<{Zookeeper}HostAndPort>_ --reassignment-json-file _<ReassignmentJsonFile>_ --execute
 ----
 +
 If you are going to throttle replication you can also pass the `--throttle` option with an inter-broker throttled rate in bytes per second. For example:
@@ -14,9 +14,9 @@ If you are going to throttle replication you can also pass the `--throttle` opti
 kafka-reassign-partitions.sh --zookeeper zookeeper1:2181 --reassignment-json-file reassignment.json --throttle 5000000 --execute
 ----
 +
-This command will print out two reassignment JSON objects. 
-The first records the current assignment for the partitions being moved. 
-You should save this to a file in case you need to revert the reassignment later on. 
+This command will print out two reassignment JSON objects.
+The first records the current assignment for the partitions being moved.
+You should save this to a file in case you need to revert the reassignment later on.
 The second JSON object is the target reassignment you have passed in your reassignment JSON file.
 
 . If you need to change the throttle during reassignment you can use the same command line with a different throttled rate. For example:
@@ -28,9 +28,9 @@ kafka-reassign-partitions.sh --zookeeper zookeeper1:2181 --reassignment-json-fil
 
 . Periodically verify whether the reassignment has completed using the `kafka-reassign-partitions.sh` command line tool. This is the same command as the previous step but with the `--verify` option instead of the `--execute` option.
 +
-[source,shell,subs=+quotes]
+[source,shell,subs="+quotes,attributes"]
 ----
-kafka-reassign-partitions.sh --zookeeper _<ZookeeperHostAndPort>_ --reassignment-json-file _<ReassignmentJsonFile>_ --verify
+kafka-reassign-partitions.sh --zookeeper _<{Zookeeper}HostAndPort>_ --reassignment-json-file _<ReassignmentJsonFile>_ --verify
 ----
 +
 For example:
@@ -40,6 +40,6 @@ For example:
 kafka-reassign-partitions.sh --zookeeper zookeeper1:2181 --reassignment-json-file reassignment.json --verify
 ----
 
-. The reassignment has finished when the `--verify` command reports each of  the partitions being moved as completed successfully. 
+. The reassignment has finished when the `--verify` command reports each of  the partitions being moved as completed successfully.
 This final `--verify` will also have the effect of removing any reassignment throttles.
 You can now delete the revert file if you saved the JSON for reverting the assignment to their original brokers.


### PR DESCRIPTION
ZooKeeper naming convention is now consistent in text.
Attribute `:Zookeeper: ZooKeeper` was created and used in the text to replace references to 'Zookeeper' and 'ZooKeeper'.

- Properties were kept as they are -- lowercase `zookeeper`
- Replaceables in code were updated/fixed
- Code formats were updated where the new attribute was introduced
